### PR TITLE
ci: Add CI to publish to PyPI with each tag release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,68 @@
+name: publish distributions
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distro to (Test)PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      # Get history and tags for dev versioning to work
+    - run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install pep517 and twine
+      run: |
+        python -m pip install pep517 --user
+        python -m pip install twine
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python -m pep517.build --source --binary --out-dir dist/ .
+    - name: Verify untagged commits have dev versions
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      run: |
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "pep517 is lacking the history and tags required to determine version number"
+          echo "intentionally erroring with 'return 1' now"
+          return 1
+        fi
+        echo "pep517.build named built distribution: ${wheel_name}"
+    - name: Verify tagged commits don't have dev versions
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        if [[ "${wheel_name}" == *"dev"* ]]; then
+          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "this is incorrrectly being treated as a dev release"
+          echo "intentionally erroring with 'return 1' now"
+          return 1
+        fi
+        echo "pep517.build named built distribution: ${wheel_name}"
+    - name: Verify the distribution
+      run: twine check dist/*
+    - name: Publish distribution 📦 to Test PyPI
+      # every PR will trigger a push event on master, so check the push event is actually coming from master
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pylhe'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,12 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      # Get history and tags for dev versioning to work
-    - run: |
-        git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install pep517 and twine
@@ -34,7 +32,7 @@ jobs:
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+        if [[ "${wheel_name}" == *"pylhe-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
           echo "pep517.build incorrectly named built distribution: ${wheel_name}"
           echo "pep517 is lacking the history and tags required to determine version number"
           echo "intentionally erroring with 'return 1' now"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = [
+    "wheel",
+    "setuptools>=30.3.0",
+    "attrs>=17.1",
+    "setuptools_scm>=1.15.0",
+    "setuptools_scm_git_archive>=1.0",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,6 @@ setup(
     include_package_data=True,
     install_requires=["networkx", "tex2pix", "pypdt"],
     extras_require=extras_require,
+    dependency_links=[],
+    use_scm_version=lambda: {"local_scheme": lambda version: ""},
 )


### PR DESCRIPTION
Adopt the pyhf publication CI workflow to publish pylhe to PyPI with teach push of a tag to `master` and to TestPyPI with each push to `master`.

This requires @lukasheinrich to first setup API tokens as `${{ secrets.test_pypi_password }}` and `${{ secrets.pypi_password }}` for TestPyPI and PyPI. This is detailed in Issue #19, but @lukasheinrich can ask me if there are any questions.

```
* Add publishing workflow to GitHub Actions for TestPyPI and PyPI using API tokens
* Add build system info required for PEP 517 type build
```

