### PR TITLE
docs: Add Scikit-HEP project badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pylhe: Python LHE interface
 
+[![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pylhe)
 [![DOI](https://zenodo.org/badge/34966492.svg)](https://zenodo.org/badge/latestdoi/34966492)
+[![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 
 [![GitHub Actions Status](https://github.com/lukasheinrich/pylhe/workflows/CI/CD/badge.svg)](https://github.com/lukasheinrich/pylhe/actions)
 [![PyPI version](https://badge.fury.io/py/pylhe.svg)](https://badge.fury.io/py/pylhe)


### PR DESCRIPTION
Add Scikit-HEP project badge to README

[![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)

additionally, add a GitHub badge that redirects back to the GitHub repo so that if the README is rendered on PyPI there is a clear link back in the page (in addition to the link)

[![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pylhe)


```
* Add Scikit-HEP project badge
* Add badge linked to GitHub repo
```