### PR TITLE
chore: Use Debian based python:3.7-slim as base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,15 @@
-FROM python:3.7-alpine3.10 as base
+ARG BASE_IMAGE=python:3.7-slim
+FROM ${BASE_IMAGE} as base
 
 FROM base as builder
 COPY . /code
-RUN cd /code && \
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install --no-install-recommends \
+        git && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt-get/lists/* && \
+    cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir . && \
     python -m pip list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=python:3.7-slim
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 
 FROM base as builder


### PR DESCRIPTION
Easier to debug for not much more space, and also allows for direct installation of SciPy and NumPy.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use python:3.7-slim as base image for Docker image builds
   - Allows for greater flexibility and easier reproducibility of user results and errors
```