### PR TITLE
feat: Use particle for labeling in visualizations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,9 @@ package_dir =
 packages = find:
 include_package_data = True
 install_requires =
-    networkx
+    networkx>=2.4
     tex2pix
-    pypdt
+    particle
 
 [options.packages.find]
 where = src

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -233,7 +233,7 @@ def readNumEvents(file):
 
 def visualize(event, outputname):
     # retrieve mapping of PDG ID to particle name as LaTeX string
-    _PDGID2LaTeXNameMap, _ = DirectionalMaps(    
+    _PDGID2LaTeXNameMap, _ = DirectionalMaps(
         "PDGID", "LATEXNAME", converters=(int, str)
     )
     # draw graph
@@ -257,5 +257,3 @@ def visualize(event, outputname):
     tex2pix.Renderer(tex).mkpdf(outputname)
     subprocess.check_call(["pdfcrop", outputname, outputname])
     os.remove("event.dot")
-
-    

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -232,7 +232,7 @@ def visualize(event, outputname):
     g = nx.DiGraph()
     for i, p in enumerate(event.particles):
         g.add_node(i, attr_dict=p.__dict__)
-        name = pypdt.particle(p.id).name
+        name = str(int(p.id)) if pypdt.particle(p.id) is None else pypdt.particle(p.id).name
         greek = [
             "gamma",
             "nu",
@@ -252,14 +252,15 @@ def visualize(event, outputname):
         ]
         for greekname in greek:
             if greekname in name:
-                name = name.replace(greekname, "\\" + greekname)
+                name = name.replace(greekname, '\\\\' + greekname)
         if "susy-" in name:
-            name = name.replace("susy-", "\\tilde ")
+            name = name.replace("susy-", '\\\\tilde ')
         g.node[i].update(texlbl="${}$".format(name))
     for i, p in enumerate(event.particles):
         for mom in p.mothers():
             g.add_edge(event.particles.index(mom), i)
-    nx.write_dot(g, "event.dot")
+    nx.nx_pydot.write_dot(g, "event.dot")
+      
     p = subprocess.Popen(["dot2tex", "event.dot"], stdout=subprocess.PIPE)
     tex2pix.Renderer(texfile=p.stdout).mkpdf(outputname)
     subprocess.check_call(["pdfcrop", outputname, outputname])

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -25,6 +25,9 @@ class LHEEvent(object):
         for p in self.particles:
             p.event = self
 
+    def visualize(self, outputname):
+        visualize(self, outputname)
+
 
 class LHEEventInfo(object):
     fieldnames = ["nparticles", "pid", "weight", "scale", "aqed", "aqcd"]

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -248,7 +248,7 @@ def visualize(event, outputname):
             iid = int(p.id)
             name = _PDGID2LaTeXNameMap[iid]
             texlbl = "${}$".format(name)
-        except:
+        except KeyError:
             texlbl = str(int(p.id))
         g.nodes[i].update(texlbl=texlbl)
     for i, p in enumerate(event.particles):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -233,9 +233,9 @@ def readNumEvents(file):
 
 def visualize(event, outputname):
     """
-    create a PDF with a visualisation of the LHE event record as a directed graph
+    Create a PDF with a visualisation of the LHE event record as a directed graph
     """
-    
+
     # retrieve mapping of PDG ID to particle name as LaTeX string
     _PDGID2LaTeXNameMap, _ = DirectionalMaps(
         "PDGID", "LATEXNAME", converters=(int, str)

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -232,6 +232,10 @@ def readNumEvents(file):
 
 
 def visualize(event, outputname):
+    """
+    create a PDF with a visualisation of the LHE event record as a directed graph
+    """
+    
     # retrieve mapping of PDG ID to particle name as LaTeX string
     _PDGID2LaTeXNameMap, _ = DirectionalMaps(
         "PDGID", "LATEXNAME", converters=(int, str)


### PR DESCRIPTION
* pypdt's particle() will return None for SUSY PDG IDs in 0.7.5
* backslash needs to be escaped twice
* networkx 1.11 has write_dot in submodule (no guarantees about this fix)