### PR TITLE
Add option to read optional event information

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -12,12 +12,9 @@ class LHEFile(object):
 
 
 class LHEEvent(object):
-    def __init__(self,
-                 eventinfo,
-                 particles,
-                 weights=None,
-                 attributes=None,
-                 optional=None):
+    def __init__(
+        self, eventinfo, particles, weights=None, attributes=None, optional=None
+    ):
         self.eventinfo = eventinfo
         self.particles = particles
         self.weights = weights
@@ -131,9 +128,7 @@ def readLHEInit(thefile):
         if element.tag == "init":
             data = element.text.split("\n")[1:-1]
             initDict["initInfo"] = LHEInit.fromstring(data[0])
-            initDict["procInfo"] = [
-                LHEProcInfo.fromstring(d) for d in data[1:]
-            ]
+            initDict["procInfo"] = [LHEProcInfo.fromstring(d) for d in data[1:]]
         if element.tag == "initrwgt":
             initDict["weightgroup"] = {}
             for child in element:
@@ -207,11 +202,16 @@ def readLHEWithAttributes(thefile):
                         for r in sub:
                             if r.tag == "wgt":
                                 eventdict["weights"][r.attrib["id"]] = float(
-                                    r.text.strip())
+                                    r.text.strip()
+                                )
                 # yield eventdict
-                yield LHEEvent(eventdict["eventinfo"], eventdict["particles"],
-                               eventdict["weights"], eventdict["attrib"],
-                               eventdict["optional"])
+                yield LHEEvent(
+                    eventdict["eventinfo"],
+                    eventdict["particles"],
+                    eventdict["weights"],
+                    eventdict["attrib"],
+                    eventdict["optional"],
+                )
     except ET.ParseError:
         print("WARNING. Parse Error.")
         return

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -210,6 +210,8 @@ def readLHEWithAttributes(thefile, parse_optional=False):
                                 eventdict["weights"][r.attrib["id"]] = float(
                                     r.text.strip())
                 # yield eventdict
+                if not parse_optional:
+                    eventdict["optional"] = None
                 yield LHEEvent(eventdict["eventinfo"], eventdict["particles"],
                                eventdict["weights"], eventdict["attrib"],
                                eventdict["optional"])

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -181,7 +181,7 @@ def readLHE(thefile):
         return
 
 
-def readLHEWithAttributes(thefile, parse_optional=False):
+def readLHEWithAttributes(thefile):
     """
     Iterate through file, similar to readLHE but also set
     weights and attributes.
@@ -196,12 +196,11 @@ def readLHEWithAttributes(thefile, parse_optional=False):
                 eventdict["particles"] = []
                 eventdict["weights"] = {}
                 eventdict["attrib"] = element.attrib
+                eventdict["optional"] = []
                 for p in particles:
                     if not p.strip().startswith("#"):
                         eventdict["particles"] += [LHEParticle.fromstring(p)]
-                    elif parse_optional:
-                        if "optional" not in list(eventdict.keys()):
-                            eventdict["optional"] = []
+                    else:
                         eventdict["optional"].append(p.strip())
                 for sub in element:
                     if sub.tag == "rwgt":
@@ -210,8 +209,6 @@ def readLHEWithAttributes(thefile, parse_optional=False):
                                 eventdict["weights"][r.attrib["id"]] = float(
                                     r.text.strip())
                 # yield eventdict
-                if not parse_optional:
-                    eventdict["optional"] = None
                 yield LHEEvent(eventdict["eventinfo"], eventdict["particles"],
                                eventdict["weights"], eventdict["attrib"],
                                eventdict["optional"])


### PR DESCRIPTION
An option to read the optional event information with `readLHEWithAttributes` and a corresponding field in `LHEEvent` was added. This optional event information is defined in the Les Houches file format according to [A Standard format for Les Houches event files](https://inspirehep.net/literature/725284) section 4.