### PR TITLE
feat: Add 'test' extra to setup.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q --no-cache-dir -e .[complete]
+        python -m pip install -q --no-cache-dir -e .[test]
         python -m pip list
     - name: Lint with Pyflakes
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,19 @@
 from setuptools import setup, find_packages
 
 extras_require = {
-    "develop": [
+    "test": [
+        "pytest",
+        "pytest-cov>=2.5.1",
+        "scikit-hep-testdata",
+        "pydocstyle",
         "check-manifest",
         "pyflakes",
-        "pre-commit",
         "black;python_version>='3.6'",  # Black is Python3 only
-        "twine",
     ],
 }
+extras_require["develop"] = sorted(
+    set(extras_require["test"] + ["pre-commit", "twine"])
+)
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 
 setup(


### PR DESCRIPTION
Add a 'test' extra to `setup.py` to make it easier to revise and install all of the dependencies needed to run the tests.


```
* Add 'test' extra
* Use 'test' extra in CI
```