### PR TITLE
feat: Use flake8 for linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+max-complexity = 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -q --no-cache-dir -e .[test]
         python -m pip list
-    - name: Lint with Pyflakes
+    - name: Lint with flake8
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
-        python -m pyflakes src
+        python -m flake8 .
     - name: Lint with Black
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,8 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.1
+    hooks:
+    - id: flake8

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         "scikit-hep-testdata",
         "pydocstyle",
         "check-manifest",
-        "pyflakes",
+        "flake8",
         "black;python_version>='3.6'",  # Black is Python3 only
     ],
 }


### PR DESCRIPTION
Given that [`flake8`](https://gitlab.com/pycqa/flake8) uses `pyflakes` but offers more configuration control adopt use of `flake8` for linting.


```
* Add flake8 to 'test' extra and .pre-commit-config.yaml
* Add .flake8 configuration file
   - flake8 does not yet support pyproject.toml
* Use flake8 for linting in CI
```