### PR TITLE
ci: Separate linting from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -q --no-cache-dir -e .[test]
         python -m pip list
-    - name: Check MANIFEST
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        check-manifest
 
   docker:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -q --no-cache-dir -e .[test]
         python -m pip list
-    - name: Lint with flake8
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        python -m flake8 .
-    - name: Lint with Black
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        black --check --diff --verbose .
     - name: Check MANIFEST
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pyflakes black
+        python -m pip install -q --no-cache-dir -e .[lint]
         python -m pip list
     - name: Lint with Pyflakes
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+
+    name: Lint Codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install pyflakes black
+        python -m pip list
+    - name: Lint with Pyflakes
+      run: |
+        python -m pyflakes .
+    - name: Lint with Black
+      run: |
+        black --check --diff --verbose .

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,10 +21,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install pep517 and twine
+    - name: Install pep517, check-manifest, and twine
       run: |
         python -m pip install pep517 --user
-        python -m pip install twine
+        python -m pip install check-manifest twine
+    - name: Check MANIFEST
+      run: |
+        check-manifest
     - name: Build a binary wheel and a source tarball
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ extras_require = {
         "pydocstyle",
         "check-manifest",
         "flake8",
-        "black;python_version>='3.6'",  # Black is Python3 only
     ],
 }
+extras_require["lint"] = sorted(set(["pyflakes", "black;python_version>='3.6'"]))
 extras_require["develop"] = sorted(
-    set(extras_require["test"] + ["pre-commit", "twine"])
+    set(extras_require["test"] + ["pre-commit", "check-manifest", "twine"])
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
# Description

Create a separate `lint` extra that can be used to lint the codebase in a separate GitHub Actions workflow then the testing of the codebase. This should allow for faster testing overall, and it also allows for linting to not block development flow until a PR is finished.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add 'lint' extra to setup.py
* Move linting into a separate GitHub Actions workflow
   - Only run lint workflow on pull_request events
* Move MANIFEST check to publish-package workflow
   - Move check-manifest to 'develop' extra
```