### PR TITLE
chore: Add Codecov coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 [![GitHub Actions Status](https://github.com/lukasheinrich/pylhe/workflows/CI/CD/badge.svg)](https://github.com/lukasheinrich/pylhe/actions)
 [![PyPI version](https://badge.fury.io/py/pylhe.svg)](https://badge.fury.io/py/pylhe)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![codecov](https://codecov.io/gh/scikit-hep/pylhe/branch/master/graphs/badge.svg?branch=master)(https://codecov.io/gh/scikit-hep/pylhe/)]
+[![codecov](https://codecov.io/gh/scikit-hep/pylhe/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/scikit-hep/pylhe/)
 
 Small and thin Python interface to read [Les Houches Event (LHE)](https://inspirehep.net/record/725284) files

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@
 [![GitHub Actions Status](https://github.com/lukasheinrich/pylhe/workflows/CI/CD/badge.svg)](https://github.com/lukasheinrich/pylhe/actions)
 [![PyPI version](https://badge.fury.io/py/pylhe.svg)](https://badge.fury.io/py/pylhe)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![codecov](https://codecov.io/gh/scikit-hep/pylhe/branch/master/graphs/badge.svg?branch=master)(https://codecov.io/gh/scikit-hep/pylhe/)]
 
 Small and thin Python interface to read [Les Houches Event (LHE)](https://inspirehep.net/record/725284) files

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 [![GitHub Actions Status](https://github.com/lukasheinrich/pylhe/workflows/CI/CD/badge.svg)](https://github.com/lukasheinrich/pylhe/actions)
 [![PyPI version](https://badge.fury.io/py/pylhe.svg)](https://badge.fury.io/py/pylhe)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![codecov](https://codecov.io/gh/scikit-hep/pylhe/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/scikit-hep/pylhe/)
+[![Code Coverage](https://codecov.io/gh/scikit-hep/pylhe/graph/badge.svg?branch=master)](https://codecov.io/gh/scikit-hep/pylhe?branch=master)
 
 Small and thin Python interface to read [Les Houches Event (LHE)](https://inspirehep.net/record/725284) files


### PR DESCRIPTION
After the codecov works now, the badge can be published via the `README.md`. (Think this should be a fast one now ;)