### PR TITLE
docs: Add preferred BibTeX citation to README

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,3 +4,7 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.cfg]
+
+[bumpversion:file:README.md]
+
+[bumpversion:file:.zenodo.json]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,26 @@
+{
+    "description": "small package to get structured data out of Les Houches Event files",
+    "license": "Apache-2.0",
+    "title": "scikit-hep/pylhe: v0.0.5",
+    "version": "v0.0.5",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "CERN",
+            "name": "Lukas Heinrich",
+            "orcid": "0000-0002-4048-7584"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+      "physics",
+      "lhe"
+    ],
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/scikit-hep/pylhe/tree/v0.0.5",
+            "relation": "isSupplementTo"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@
 [![Code Coverage](https://codecov.io/gh/scikit-hep/pylhe/graph/badge.svg?branch=master)](https://codecov.io/gh/scikit-hep/pylhe?branch=master)
 
 Small and thin Python interface to read [Les Houches Event (LHE)](https://inspirehep.net/record/725284) files
+
+## Citation
+
+The preferred BibTeX entry for citation of `pylhe` is
+
+```
+@software{pylhe,
+  author = "{Heinrich, Lukas}",
+  title = "{pylhe: v0.0.5}",
+  version = {v0.0.5},
+  doi = {10.5281/zenodo.1217031},
+  url = {https://github.com/scikit-hep/pylhe},
+}
+```


### PR DESCRIPTION
Add a preferred BibTeX citation to README that gets updated with releases through `bumpversion`. Additionally, add control over metadata shown on Zenodo through `.zenodo.json`.

```
* Add preferred BibTeX citation to README
* Add .zenodo.json to control metadata for releases on Zenodo
* Control the citation information through bumpversion
```