### PR TITLE
chore: Migrate from pep517 to python-build

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,23 +35,23 @@ jobs:
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"pylhe-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "python-build incorrectly named built distribution: ${wheel_name}"
           echo "pep517 is lacking the history and tags required to determine version number"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
       if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "python-build incorrectly named built distribution: ${wheel_name}"
           echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,6 +23,7 @@ jobs:
         python-version: 3.7
     - name: Install python-build, check-manifest, and twine
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -36,7 +36,7 @@ jobs:
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"pylhe-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
           echo "python-build incorrectly named built distribution: ${wheel_name}"
-          echo "pep517 is lacking the history and tags required to determine version number"
+          echo "python-build is lacking the history and tags required to determine version number"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,10 +21,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Install pep517, check-manifest, and twine
+    - name: Install python-build, check-manifest, and twine
       run: |
-        python -m pip install pep517 --user
-        python -m pip install check-manifest twine
+        python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
         check-manifest
     - name: Build a binary wheel and a source tarball
       run: |
-        python -m pep517.build --source --binary --out-dir dist/ .
+        python -m build --sdist --wheel --outdir dist/ .
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |


### PR DESCRIPTION
```
* Migrate from the deprecated pep517.build to python-build CLI for builds for packaging
   - c.f. https://github.com/pypa/pep517/pull/83
```