### PR TITLE
ci: Add workflow dispatch support and update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
     - master
+  workflow_dispatch:
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,10 +17,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -59,12 +59,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
```
* Add workflow dispatch to all GitHub Action workflows
* Update to Python 3.8 in package publishing workflow
* Update to v1.3.1 of the pypa/gh-action-pypi-publish action in package publishing workflow
```