### PR TITLE
chore: Update pre-commit hook revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     - id: black
       language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
     - id: flake8


### PR DESCRIPTION
```
* Update Black pre-commit hook to use rev v20.8b1
   - Using pinned revs is the recommended approach for pre-commit: https://github.com/psf/black/issues/420
* Update flake8 pre-commit hook to use rev v3.8.3
```