### PR TITLE
chore: Migrate to bump2version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,15 @@ extras_require = {
         "pytest-cov>=2.5.1",
         "scikit-hep-testdata>=0.3.1",
         "pydocstyle",
-        "check-manifest",
         "flake8",
     ],
 }
 extras_require["lint"] = sorted(set(["pyflakes", "black;python_version>='3.6'"]))
 extras_require["develop"] = sorted(
-    set(extras_require["test"] + ["pre-commit", "check-manifest", "twine"])
+    set(
+        extras_require["test"]
+        + ["pre-commit", "check-manifest", "bump2version~=1.0", "twine"]
+    )
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,11 @@
 from setuptools import setup
 
 extras_require = {
-    "test": [
-        "pytest",
-        "pytest-cov>=2.5.1",
-        "scikit-hep-testdata>=0.3.1",
-        "pydocstyle",
-        "flake8",
-    ],
+    "test": ["pytest", "pytest-cov>=2.5.1", "scikit-hep-testdata>=0.3.1", "pydocstyle"],
 }
-extras_require["lint"] = sorted(set(["pyflakes", "black;python_version>='3.6'"]))
+extras_require["lint"] = sorted(
+    set(["flake8", "pyflakes", "black;python_version>='3.6'"])
+)
 extras_require["develop"] = sorted(
     set(
         extras_require["test"]


### PR DESCRIPTION
[`bumpversion` is no longer maintained](https://github.com/peritus/bumpversion) (as of apparently November 2019). Given this we should probably take the project's advice

> 🎬 If you want to start using `bumpversion`, you're best advised to install one of the maintained forks, e.g. ➡ @ c4urself's [`bump2version`](https://github.com/c4urself/bump2version/#installation).

This PR migrates to using `bump2version` `v1.X` release series.

**Suggested squash and merge commit message:**

```
* Add bump2version to the develop extra
   - bumpversion is no longer maintained and bump2version is the recommended fork
   - Use bump2version v1.X series
* Migrate flake8 to the lint extra
```