### PR TITLE
ci: Use flake8 in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,9 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -q --no-cache-dir -e .[lint]
         python -m pip list
-    - name: Lint with Pyflakes
+    - name: Lint with flake8
       run: |
-        python -m pyflakes .
+        python -m flake8 .
     - name: Lint with Black
       run: |
         black --check --diff --verbose .

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@ from setuptools import setup
 extras_require = {
     "test": ["pytest", "pytest-cov>=2.5.1", "scikit-hep-testdata>=0.3.1", "pydocstyle"],
 }
-extras_require["lint"] = sorted(
-    set(["flake8", "pyflakes", "black;python_version>='3.6'"])
-)
+extras_require["lint"] = sorted(set(["flake8", "black;python_version>='3.6'"]))
 extras_require["develop"] = sorted(
     set(
         extras_require["test"]


### PR DESCRIPTION
Use `flake8` to lint the codebase in the `lint` GitHub Actions workflow.

```
* Use flake8 in the lint workflow
* Remove pyflakes form the lint extra
```