### PR TITLE
ci: Publish releases to PyPI through GitHub releases

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
     - master
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -66,7 +66,7 @@ jobs:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pylhe'
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe'
       uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This PR uses publication type releases to publish to PyPI by running the publication workflow on `published` `release` events and then verifying that the PyPI upload step is running on one. This follows what I'll call the `corner` model (which I now think is how GitHub Actions assumed people would do things): 

This follows the example that @dfm has setup in [`corner`](https://github.com/dfm/corner.py) with running the workflow on [`published` `release` events](https://github.com/dfm/corner.py/blob/efd25380ee121c4d565ed9aff2f98e184cc9dcef/.github/workflows/tests.yml#L7-L8) and then only running the [publish to PyPI step on that conditions](https://github.com/dfm/corner.py/blob/efd25380ee121c4d565ed9aff2f98e184cc9dcef/.github/workflows/tests.yml#L82). To instigate this workflow one would do the following:

- Locally on `master` run:

```
$ git checkout master && git pull # verify that you're on master and synced with GitHub
$ bump2version <part> # bump the version and create a commit and tag
$ git push origin master --tags # push the commit and the tag to GitHub, causing TestPyPI to publish
```
- Then on GitHub:
   1. Go to releases: https://github.com/scikit-hep/pylhe/releases
   2. Click "Draft a new release"
   3. On the new page enter the tag you just pushed (e.g. `v0.1.0`) in the "Tag version" box and the "Release title" box (to make it easy unless you really want to get descriptive)
   4. Enter any release notes and click "Publish release"
- This then kicks of the publication CD workflow that will use the PyPI API key to publish.

This is a bit different from the `pyhf` way of doing things, but also lets things run through on TestPyPI on the tag before things are ever released.

Let me know your thoughts @lukasheinrich.

```
* Publish to PyPI through published release events triggered through GitHub releases
   - c.f. https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release
```