### PR TITLE
fix: Don't run publishing workflow on tags to avoid errors

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - v*
   pull_request:
     branches:
     - master
@@ -34,24 +32,12 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: |
         python -m build --sdist --wheel --outdir dist/ .
-    - name: Verify untagged commits have dev versions
-      if: "!startsWith(github.ref, 'refs/tags/')"
+    - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"pylhe-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+        if [[ "${wheel_name}" == *"pylhe-0.1.dev"* ]]; then
           echo "python-build incorrectly named built distribution: ${wheel_name}"
           echo "python-build is lacking the history and tags required to determine version number"
-          echo "intentionally erroring with 'return 1' now"
-          return 1
-        fi
-        echo "python-build named built distribution: ${wheel_name}"
-    - name: Verify tagged commits don't have dev versions
-      if: startsWith(github.ref, 'refs/tags')
-      run: |
-        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "python-build incorrectly named built distribution: ${wheel_name}"
-          echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.1
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
With the old workflow if the publishing workflow was run after a new tag was created

```
$ bump2version <part>
$ git push origin master --tags
```

no release would get published to TestPyPI as the workflow that would get kicked off from the `push` event to `master` (and so NOT a `tag` event) would fail the "Verify untagged commits have dev versions" step

https://github.com/scikit-hep/pylhe/blob/dd781b7040df6d5638c71ab880f19be76eb512b2/.github/workflows/publish-package.yml#L37-L47

as it would

https://github.com/scikit-hep/pylhe/blob/dd781b7040df6d5638c71ab880f19be76eb512b2/.github/workflows/publish-package.yml#L38

but then also `"${wheel_name}" != *"dev"*` given that it comes from a tag. So nothing gets published.

Similarly, the workflow that would get kicked off from the `tag` event will just run though but will pass

https://github.com/scikit-hep/pylhe/blob/dd781b7040df6d5638c71ab880f19be76eb512b2/.github/workflows/publish-package.yml#L61-L67

as it is has `github.ref` of `'refs/tags/'` and so nothing happens at all.

This PR fixes that by just letting pushes to `master` publish to TestPyPI and then letting the releases publish to PyPI.

```
* Don't run publishing workflow on tag events
   - Avoid publishing errors due to 'push' or 'tag' events and checks for tags
* Update pypa/gh-action-pypi-publish action to v1.4.1
```
