### PR TITLE
fix: Require Python 2.7 or later or Python 3.6+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=2.7
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 install_requires =
     networkx>=2.4
     tex2pix

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
+python_requires = >=2.7
 install_requires =
     networkx>=2.4
     tex2pix

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 include_package_data = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 install_requires =
-    networkx>=2.4
+    networkx>=2.2
     tex2pix
     particle
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -257,7 +257,8 @@ def visualize(event, outputname):
     nx.nx_pydot.write_dot(g, "event.dot")
 
     p = subprocess.Popen(["dot2tex", "event.dot"], stdout=subprocess.PIPE)
-    tex = p.stdout.read().decode()
+    # TODO: Remove explicit str wrapping once Python 2 dropped
+    tex = str(p.stdout.read().decode())
     tex2pix.Renderer(tex).mkpdf(outputname)
     subprocess.check_call(["pdfcrop", outputname, outputname])
     os.remove("event.dot")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -9,6 +9,7 @@ def test_visualize(tmpdir):
     start_event = 1
     stop_event = 2
     # TODO: Use f-strings once Python 2 dropped
-    filename = tmpdir.join("event{}.pdf".format(start_event))
+    # TODO: Remove explicit str wrapping once Python 2 dropped
+    filename = str(tmpdir.join("event{}.pdf".format(start_event)))
     for idx, event in enumerate(itertools.islice(events, start_event, stop_event)):
         pylhe.visualize(event, filename)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -8,6 +8,7 @@ def test_visualize(tmpdir):
     events = pylhe.readLHEWithAttributes(lhe_file)
     start_event = 1
     stop_event = 2
-    filename = tmpdir.join(f"event{start_event}.pdf")
+    # TODO: Use f-strings once Python 2 dropped
+    filename = tmpdir.join("event{}.pdf".format(start_event))
     for idx, event in enumerate(itertools.islice(events, start_event, stop_event)):
         pylhe.visualize(event, filename)


### PR DESCRIPTION
Partially addresses Issue #43 

In preparation of `v0.1.0` drop Python 2.7 support and support for Python 3 older than 3.6

```
* Require Python 2.7 or later or Python 3.6+ for install
* Add Python 2.7 to PyPI metadata
   - To be dropped after v0.1.0 is published
* Temporarily loosen networkx requirements to >=2.2 to allow for Python 2.7 install
   - Test Python 2.7 until v0.1.0 is published
* Temporarily explicitly wrap paths as str and remove use of f-strings until Python 2 dropped
```