### PR TITLE
feat: Drop Python 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -38,7 +36,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+python_requires = >=3.6
 install_requires =
     networkx>=2.2
     tex2pix

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -257,8 +257,7 @@ def visualize(event, outputname):
     nx.nx_pydot.write_dot(g, "event.dot")
 
     p = subprocess.Popen(["dot2tex", "event.dot"], stdout=subprocess.PIPE)
-    # TODO: Remove explicit str wrapping once Python 2 dropped
-    tex = str(p.stdout.read().decode())
+    tex = p.stdout.read().decode()
     tex2pix.Renderer(tex).mkpdf(outputname)
     subprocess.check_call(["pdfcrop", outputname, outputname])
     os.remove("event.dot")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -8,8 +8,6 @@ def test_visualize(tmpdir):
     events = pylhe.readLHEWithAttributes(lhe_file)
     start_event = 1
     stop_event = 2
-    # TODO: Use f-strings once Python 2 dropped
-    # TODO: Remove explicit str wrapping once Python 2 dropped
-    filename = str(tmpdir.join("event{}.pdf".format(start_event)))
+    filename = tmpdir.join(f"event{start_event}.pdf")
     for idx, event in enumerate(itertools.islice(events, start_event, stop_event)):
         pylhe.visualize(event, filename)


### PR DESCRIPTION
Resolves #43 

```
* Drop support of Python 2.7 and require Python 3.6 or newer
   - Remove Python 2 PyPI metadata
   - Drop testing of Python 2.7
* Remove Python 2.7 specific stopgap fixes
```