### PR TITLE
docs: Fix Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pylhe: Python LHE interface
 
 [![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pylhe)
-[![DOI](https://zenodo.org/badge/34966492.svg)](https://zenodo.org/badge/latestdoi/34966492)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1217031.svg)](https://doi.org/10.5281/zenodo.1217031)
 [![Scikit-HEP](https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg)](https://scikit-hep.org/)
 
 [![PyPI version](https://badge.fury.io/py/pylhe.svg)](https://badge.fury.io/py/pylhe)


### PR DESCRIPTION
[![DOI](https://zenodo.org/badge/34966492.svg)](https://zenodo.org/badge/latestdoi/34966492)

```
* Have Zenodo badge point to all releases DOI
  - c.f. https://doi.org/10.5281/zenodo.1217031
```