### PR TITLE
build: Use compatible release syntax to give ranges for install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     networkx~=2.2
-    tex2pix
-    particle
+    tex2pix~=0.3
+    particle~=0.12
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    networkx>=2.2
+    networkx~=2.2
     tex2pix
     particle
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 from setuptools import setup
 
 extras_require = {}
-extras_require["lint"] = sorted({"flake8", "black;python_version>='3.6'"})
+extras_require["lint"] = sorted({"flake8", "black"})
 # c.f. https://networkx.org/documentation/stable/install.html#optional-packages
-extras_require["viz"] = sorted({"pydot", "dot2tex"})
+extras_require["viz"] = sorted({"pydot~=1.4", "dot2tex~=2.11"})
 extras_require["test"] = sorted(
     set(
         extras_require["viz"]
-        + ["pytest", "pytest-cov>=2.5.1", "scikit-hep-testdata>=0.3.1", "pydocstyle"]
+        + [
+            "pytest~=6.0",
+            "pytest-cov>=2.5.1",
+            "scikit-hep-testdata>=0.3.1",
+            "pydocstyle",
+        ]
     )
 )
 extras_require["develop"] = sorted(


### PR DESCRIPTION
# Description

To give releases longer stability and lifetimes upper bounds are required on core dependencies to ensure that breaking API changes to not break old releases. This is a builtin functionality of [PEP 440's compatible release syntax](https://www.python.org/dev/peps/pep-0440/#compatible-release). This PR applies compatible release syntax (`~=`) to all of the dependencies in `install_requires`, establishing lower bounds from when they were added and similarly upper bounds.

---
[Quick summary of compatible release syntax](https://github.com/mwouts/jupytext/pull/596):

In [PEP 440's "Compatible release" section](https://www.python.org/dev/peps/pep-0440/#compatible-release)

> For a given release identifier V.N, the compatible release clause is approximately equivalent to the pair of comparison clauses:
> ```
>>= V.N, == V.*
>```

As an example, in a fresh virtual environment

```
(myst-example) $ pip install -qq "myst-parser~=0.8"
(myst-example) $ pip list | grep myst
myst-parser                   0.12.10
(myst-example) $ pip install --upgrade -qq "myst-parser~=0.8.0"
(myst-example) $ pip list | grep myst
myst-parser                   0.8.2
```
---


```
* Use compatible release syntax to establish release ranges for core dependencies
   - c.f. https://www.python.org/dev/peps/pep-0440/#compatible-release
```
