### PR TITLE
build: Use Particle v0.14 for minimal compatible release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ python_requires = >=3.6
 install_requires =
     networkx~=2.2
     tex2pix~=0.3
-    particle~=0.12
+    particle~=0.14
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Trivial update to latest series. Not that the updates will matter to you here, but no harm in using the latest and greatest.
(In fact explicit support for Python 3.9 only came with the 0.13 series, so better update in any case.)