### PR TITLE
ci: Add pre-commit hooks from pre-commit-hooks recommended by Scikit-HEP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,24 @@
 repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-symlinks
+    - id: check-json
+    - id: check-yaml
+    - id: check-toml
+    - id: check-xml
+    - id: debug-statements
+    - id: end-of-file-fixer
+      # exclude generated files
+      exclude: ^validation/|\.dtd$|\.json$|\.xml$
+    - id: mixed-line-ending
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace
+      # exclude generated files
+      exclude: ^validation/|\.dtd$|\.xml$
 -   repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     - id: debug-statements
     - id: end-of-file-fixer
     - id: mixed-line-ending
-    - id: requirements-txt-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/psf/black
     rev: 20.8b1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,9 @@ repos:
     - id: check-xml
     - id: debug-statements
     - id: end-of-file-fixer
-      # exclude generated files
-      exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-      # exclude generated files
-      exclude: ^validation/|\.dtd$|\.xml$
 -   repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:


### PR DESCRIPTION
 Add pre-commit hooks for [`pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks) ("Some out-of-the-box hooks for pre-commit.") [recommended by the Scikit-HEP developer guide](https://scikit-hep.org/developer/style#pre-commit).


```
* Add pre-commit hooks for pre-commit-hooks recommended by Scikit-HEP
   - c.f. https://github.com/pre-commit/pre-commit-hooks
   - c.f. https://scikit-hep.org/developer/style#pre-commit
```
