### PR TITLE
build: Remove universal wheel flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
     Programming Language :: Python :: 3.9
 
 [bdist_wheel]
-universal = 1
 
 [options]
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
-[bdist_wheel]
-
 [options]
 setup_requires =
     setuptools_scm>=1.15.0


### PR DESCRIPTION
```
* Remove universal wheel setting as pylhe is Python 3 only
   - Fixes py2.py3 tag naming scheme for wheels
```