### PR TITLE
feat: Add support for reading compressed files

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -4,6 +4,7 @@ import networkx as nx
 import tex2pix
 import subprocess
 from particle.converters.bimap import DirectionalMaps
+import gzip
 
 
 class LHEFile:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -4,7 +4,6 @@ import networkx as nx
 import tex2pix
 import subprocess
 from particle.converters.bimap import DirectionalMaps
-import gzip
 
 
 class LHEFile:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -130,11 +130,15 @@ def _open_gzip_file(filepath):
     if not Path(filepath).name.lower().endswith(".gz"):
         return filepath
 
-    with gzip.open(filepath, "r") as gzip_file:
-        try:
-            gzip_file.read(1)
-        except (OSError, gzip.BadGzipFile) as err:
-            raise err(f"Input file {filepath} is not a compressed file.\n")
+    with open(filepath, "rb") as gzip_file:
+        header = gzip_file.read(2)
+
+    gzip_magic_number = b"\x1f\x8b"
+    if header != gzip_magic_number:
+        raise OSError(
+            f"Input file {filepath} is not a compressed file.\n"
+            + f"{filepath} has header of {header} and not gzip's {gzip_magic_number}.\n"
+        )
     return gzip.open(filepath, "r")
 
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,6 +2,7 @@ import gzip
 import os
 import subprocess
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import networkx as nx
 import tex2pix
@@ -126,7 +127,7 @@ def _open_gzip_file(filepath):
     """
     Checks to see if a file is compressed, and if so, open it with gzip
     """
-    if not filepath.lower().endswith(".gz"):
+    if not Path(filepath).name.lower().endswith(".gz"):
         return filepath
 
     with gzip.open(filepath, "r") as gzip_file:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -132,13 +132,13 @@ def _open_gzip_file(filepath):
 
     with open(filepath, "rb") as gzip_file:
         header = gzip_file.read(2)
-
     gzip_magic_number = b"\x1f\x8b"
     if header != gzip_magic_number:
         raise OSError(
             f"Input file {filepath} is not a compressed file.\n"
             + f"{filepath} has header of {header} and not gzip's {gzip_magic_number}.\n"
         )
+
     return gzip.open(filepath, "r")
 
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -122,36 +122,39 @@ def loads():
     pass
 
 
-def _extract_fileobj(fileobj):
+def _extract_fileobj(filepath):
     """
     Checks to see if a file is compressed, and if so, extract it with gzip
     so that the uncompressed file can be returned.
+    It returns a filename or file object containing XML data that will be
+    ingested by ``xml.etree.ElementTree.iterparse``.
 
     Args:
-        fileobj: A file path or a Python file object.
+        filepath: A path-like object or str.
 
     Returns:
-        pathlib.PosixPath or gzip.GzipFile: An uncompressed file object.
+        pathlib.PosixPath or gzip.GzipFile: A filename or file object containing
+          XML data.
     """
-    with open(fileobj, "rb") as gzip_file:
+    with open(filepath, "rb") as gzip_file:
         header = gzip_file.read(2)
     gzip_magic_number = b"\x1f\x8b"
 
-    return gzip.GzipFile(fileobj) if header == gzip_magic_number else fileobj
+    return gzip.GzipFile(filepath) if header == gzip_magic_number else filepath
 
 
-def readLHEInit(fileobj):
+def readLHEInit(filepath):
     """
     Read and return the init blocks. This encodes the weight group
     and related things according to https://arxiv.org/abs/1405.1067
 
     Args:
-        fileobj: A file path or a Python file object.
+        filepath: A path-like object or str.
 
     Returns:
         dict: Dictionary containing the init blocks of the LHE file.
     """
-    fileobj = _extract_fileobj(fileobj)
+    fileobj = _extract_fileobj(filepath)
     initDict = {}
     for event, element in ET.iterparse(fileobj, events=["end"]):
         if element.tag == "init":
@@ -189,8 +192,8 @@ def readLHEInit(fileobj):
     return initDict
 
 
-def readLHE(fileobj):
-    fileobj = _extract_fileobj(fileobj)
+def readLHE(filepath):
+    fileobj = _extract_fileobj(filepath)
     try:
         for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":
@@ -206,12 +209,12 @@ def readLHE(fileobj):
         return
 
 
-def readLHEWithAttributes(fileobj):
+def readLHEWithAttributes(filepath):
     """
     Iterate through file, similar to readLHE but also set
     weights and attributes.
     """
-    fileobj = _extract_fileobj(fileobj)
+    fileobj = _extract_fileobj(filepath)
     try:
         for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -138,9 +138,7 @@ def _extract_fileobj(fileobj):
         header = gzip_file.read(2)
     gzip_magic_number = b"\x1f\x8b"
 
-    if header == gzip_magic_number:
-        fileobj = gzip.GzipFile(fileobj)
-    return fileobj
+    return gzip.GzipFile(fileobj) if header == gzip_magic_number else fileobj
 
 
 def readLHEInit(fileobj):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -128,8 +128,7 @@ def _extract_fileobj(fileobj):
     so that the uncompressed file can be returned.
 
     Args:
-        fileobj: A file object that can be a file, file object, or a
-          compressed file.
+        fileobj: A file path or a Python file object.
 
     Returns:
         pathlib.PosixPath or gzip.GzipFile: An uncompressed file object.
@@ -143,9 +142,14 @@ def _extract_fileobj(fileobj):
 
 def readLHEInit(fileobj):
     """
-    Read the init blocks. Return dict. This encodes the weight group
+    Read and return the init blocks. This encodes the weight group
     and related things according to https://arxiv.org/abs/1405.1067
-    This function returns a dict.
+
+    Args:
+        fileobj: A file path or a Python file object.
+
+    Returns:
+        dict: Dictionary containing the init blocks of the LHE file.
     """
     fileobj = _extract_fileobj(fileobj)
     initDict = {}

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -129,10 +129,11 @@ def _extract_gzip_file(fileobj):
     so that the uncompressed file can be returned.
 
     Args:
-        fileobj: A file object that can be a file or a compressed file.
+        fileobj: A file object that can be a file, file object, or a
+          compressed file.
 
     Returns:
-        file: An uncompressed file.
+        pathlib.PosixPath or gzip.GzipFile: An uncompressed file object.
     """
     if not Path(fileobj).name.lower().endswith(".gz"):
         return fileobj
@@ -147,10 +148,9 @@ def _extract_gzip_file(fileobj):
             + f"{fileobj} has header of {header} and not gzip's {gzip_magic_number}.\n"
         )
 
-    with gzip.open(fileobj, "rb") as readfile:
-        extracted_file = readfile.read()
-
-    return extracted_file
+    with gzip.open(fileobj, "rb") as gzip_file:
+        gzip_fileobj = gzip.GzipFile(filename=gzip_file.filename)
+    return gzip_fileobj
 
 
 def readLHEInit(fileobj):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -148,9 +148,7 @@ def _extract_fileobj(fileobj):
             + f"{fileobj} has header of {header} and not gzip's {gzip_magic_number}.\n"
         )
 
-    with gzip.open(fileobj, "rb") as gzip_file:
-        gzip_fileobj = gzip.GzipFile(filename=gzip_file.filename)
-    return gzip_fileobj
+    return gzip.GzipFile(filename=Path(fileobj).name)
 
 
 def readLHEInit(fileobj):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -123,34 +123,34 @@ def loads():
     pass
 
 
-def _open_gzip_file(filepath):
+def _open_gzip_file(fileobj):
     """
     Checks to see if a file is compressed, and if so, open it with gzip
     """
-    if not Path(filepath).name.lower().endswith(".gz"):
-        return filepath
+    if not Path(fileobj).name.lower().endswith(".gz"):
+        return fileobj
 
-    with open(filepath, "rb") as gzip_file:
+    with open(fileobj, "rb") as gzip_file:
         header = gzip_file.read(2)
     gzip_magic_number = b"\x1f\x8b"
     if header != gzip_magic_number:
         raise OSError(
-            f"Input file {filepath} is not a compressed file.\n"
-            + f"{filepath} has header of {header} and not gzip's {gzip_magic_number}.\n"
+            f"Input file {fileobj} is not a compressed file.\n"
+            + f"{fileobj} has header of {header} and not gzip's {gzip_magic_number}.\n"
         )
 
-    return gzip.open(filepath, "r")
+    return gzip.open(fileobj, "r")
 
 
-def readLHEInit(filepath):
+def readLHEInit(fileobj):
     """
     Read the init blocks. Return dict. This encodes the weight group
     and related things according to https://arxiv.org/abs/1405.1067
     This function returns a dict.
     """
-    filepath = _open_gzip_file(filepath)
+    fileobj = _open_gzip_file(fileobj)
     initDict = {}
-    for event, element in ET.iterparse(filepath, events=["end"]):
+    for event, element in ET.iterparse(fileobj, events=["end"]):
         if element.tag == "init":
             data = element.text.split("\n")[1:-1]
             initDict["initInfo"] = LHEInit.fromstring(data[0])
@@ -186,10 +186,10 @@ def readLHEInit(filepath):
     return initDict
 
 
-def readLHE(filepath):
-    filepath = _open_gzip_file(filepath)
+def readLHE(fileobj):
+    fileobj = _open_gzip_file(fileobj)
     try:
-        for event, element in ET.iterparse(filepath, events=["end"]):
+        for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":
                 data = element.text.split("\n")[1:-1]
                 eventdata, particles = data[0], data[1:]
@@ -203,14 +203,14 @@ def readLHE(filepath):
         return
 
 
-def readLHEWithAttributes(filepath):
+def readLHEWithAttributes(fileobj):
     """
     Iterate through file, similar to readLHE but also set
     weights and attributes.
     """
-    filepath = _open_gzip_file(filepath)
+    fileobj = _open_gzip_file(fileobj)
     try:
-        for event, element in ET.iterparse(filepath, events=["end"]):
+        for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":
                 eventdict = {}
                 data = element.text.split("\n")[1:-1]

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -148,7 +148,7 @@ def _extract_fileobj(fileobj):
             + f"{fileobj} has header of {header} and not gzip's {gzip_magic_number}.\n"
         )
 
-    return gzip.GzipFile(filename=Path(fileobj).name)
+    return gzip.GzipFile(filename=Path(fileobj))
 
 
 def readLHEInit(fileobj):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -123,7 +123,7 @@ def loads():
     pass
 
 
-def _extract_gzip_file(fileobj):
+def _extract_fileobj(fileobj):
     """
     Checks to see if a file is compressed, and if so, extract it with gzip
     so that the uncompressed file can be returned.
@@ -159,7 +159,7 @@ def readLHEInit(fileobj):
     and related things according to https://arxiv.org/abs/1405.1067
     This function returns a dict.
     """
-    fileobj = _extract_gzip_file(fileobj)
+    fileobj = _extract_fileobj(fileobj)
     initDict = {}
     for event, element in ET.iterparse(fileobj, events=["end"]):
         if element.tag == "init":
@@ -198,7 +198,7 @@ def readLHEInit(fileobj):
 
 
 def readLHE(fileobj):
-    fileobj = _extract_gzip_file(fileobj)
+    fileobj = _extract_fileobj(fileobj)
     try:
         for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":
@@ -219,7 +219,7 @@ def readLHEWithAttributes(fileobj):
     Iterate through file, similar to readLHE but also set
     weights and attributes.
     """
-    fileobj = _extract_gzip_file(fileobj)
+    fileobj = _extract_fileobj(fileobj)
     try:
         for event, element in ET.iterparse(fileobj, events=["end"]):
             if element.tag == "event":

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,7 +2,6 @@ import gzip
 import os
 import subprocess
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 import networkx as nx
 import tex2pix
@@ -135,20 +134,13 @@ def _extract_fileobj(fileobj):
     Returns:
         pathlib.PosixPath or gzip.GzipFile: An uncompressed file object.
     """
-    if Path(fileobj).suffix != ".gz":
-        return fileobj
-
-    # Verify actually a gzip file
     with open(fileobj, "rb") as gzip_file:
         header = gzip_file.read(2)
     gzip_magic_number = b"\x1f\x8b"
-    if header != gzip_magic_number:
-        raise OSError(
-            f"Input file {fileobj} is not a compressed file.\n"
-            + f"{fileobj} has header of {header} and not gzip's {gzip_magic_number}.\n"
-        )
 
-    return gzip.GzipFile(filename=Path(fileobj))
+    if header == gzip_magic_number:
+        fileobj = gzip.GzipFile(fileobj)
+    return fileobj
 
 
 def readLHEInit(fileobj):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -134,7 +134,7 @@ def _open_gzip_file(filepath):
             gzip_file.read(1)
         except (OSError, gzip.BadGzipFile) as err:
             raise err(f"Input file {filepath} is not a compressed file.\n")
-        return gzip_file
+    return gzip.open(filepath, "r")
 
 
 def readLHEInit(filepath):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1,10 +1,11 @@
+import gzip
 import os
+import subprocess
 import xml.etree.ElementTree as ET
+
 import networkx as nx
 import tex2pix
-import subprocess
 from particle.converters.bimap import DirectionalMaps
-import gzip
 
 
 class LHEFile:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -135,7 +135,7 @@ def _extract_fileobj(fileobj):
     Returns:
         pathlib.PosixPath or gzip.GzipFile: An uncompressed file object.
     """
-    if not Path(fileobj).name.lower().endswith(".gz"):
+    if Path(fileobj).suffix != ".gz":
         return fileobj
 
     # Verify actually a gzip file

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -126,21 +126,22 @@ def _extract_fileobj(filepath):
     """
     Checks to see if a file is compressed, and if so, extract it with gzip
     so that the uncompressed file can be returned.
-    It returns a filename or file object containing XML data that will be
-    ingested by ``xml.etree.ElementTree.iterparse``.
+    It returns a file object containing XML data that will be ingested by
+    ``xml.etree.ElementTree.iterparse``.
 
     Args:
         filepath: A path-like object or str.
 
     Returns:
-        pathlib.PosixPath or gzip.GzipFile: A filename or file object containing
-          XML data.
+        _io.BufferedReader or gzip.GzipFile: A file object containing XML data.
     """
     with open(filepath, "rb") as gzip_file:
         header = gzip_file.read(2)
     gzip_magic_number = b"\x1f\x8b"
 
-    return gzip.GzipFile(filepath) if header == gzip_magic_number else filepath
+    return (
+        gzip.GzipFile(filepath) if header == gzip_magic_number else open(filepath, "rb")
+    )
 
 
 def readLHEInit(filepath):
@@ -154,56 +155,56 @@ def readLHEInit(filepath):
     Returns:
         dict: Dictionary containing the init blocks of the LHE file.
     """
-    fileobj = _extract_fileobj(filepath)
     initDict = {}
-    for event, element in ET.iterparse(fileobj, events=["end"]):
-        if element.tag == "init":
-            data = element.text.split("\n")[1:-1]
-            initDict["initInfo"] = LHEInit.fromstring(data[0])
-            initDict["procInfo"] = [LHEProcInfo.fromstring(d) for d in data[1:]]
-        if element.tag == "initrwgt":
-            initDict["weightgroup"] = {}
-            for child in element:
-                # Find all weightgroups
-                if child.tag == "weightgroup" and child.attrib != {}:
-                    try:
-                        wg_type = child.attrib["type"]
-                    except KeyError:
-                        print("weightgroup must have attribute 'type'")
-                        raise
-                    _temp = {"attrib": child.attrib}
-                    _temp["weights"] = {}
-                    # Iterate over all weights in this weightgroup
-                    for w in child:
-                        if not w.tag == "weight":
-                            continue
+    with _extract_fileobj(filepath) as fileobj:
+        for event, element in ET.iterparse(fileobj, events=["end"]):
+            if element.tag == "init":
+                data = element.text.split("\n")[1:-1]
+                initDict["initInfo"] = LHEInit.fromstring(data[0])
+                initDict["procInfo"] = [LHEProcInfo.fromstring(d) for d in data[1:]]
+            if element.tag == "initrwgt":
+                initDict["weightgroup"] = {}
+                for child in element:
+                    # Find all weightgroups
+                    if child.tag == "weightgroup" and child.attrib != {}:
                         try:
-                            wg_id = w.attrib["id"]
+                            wg_type = child.attrib["type"]
                         except KeyError:
-                            print("weight must have attribute 'id'")
+                            print("weightgroup must have attribute 'type'")
                             raise
-                        _w = {"attrib": w.attrib}
-                        _w["name"] = w.text.strip()
-                        _temp["weights"][wg_id] = _w
+                        _temp = {"attrib": child.attrib}
+                        _temp["weights"] = {}
+                        # Iterate over all weights in this weightgroup
+                        for w in child:
+                            if not w.tag == "weight":
+                                continue
+                            try:
+                                wg_id = w.attrib["id"]
+                            except KeyError:
+                                print("weight must have attribute 'id'")
+                                raise
+                            _w = {"attrib": w.attrib}
+                            _w["name"] = w.text.strip()
+                            _temp["weights"][wg_id] = _w
 
-                    initDict["weightgroup"][wg_type] = _temp
-        if element.tag == "event":
-            break
+                        initDict["weightgroup"][wg_type] = _temp
+            if element.tag == "event":
+                break
     return initDict
 
 
 def readLHE(filepath):
-    fileobj = _extract_fileobj(filepath)
     try:
-        for event, element in ET.iterparse(fileobj, events=["end"]):
-            if element.tag == "event":
-                data = element.text.split("\n")[1:-1]
-                eventdata, particles = data[0], data[1:]
-                eventinfo = LHEEventInfo.fromstring(eventdata)
-                particle_objs = []
-                for p in particles:
-                    particle_objs += [LHEParticle.fromstring(p)]
-                yield LHEEvent(eventinfo, particle_objs)
+        with _extract_fileobj(filepath) as fileobj:
+            for event, element in ET.iterparse(fileobj, events=["end"]):
+                if element.tag == "event":
+                    data = element.text.split("\n")[1:-1]
+                    eventdata, particles = data[0], data[1:]
+                    eventinfo = LHEEventInfo.fromstring(eventdata)
+                    particle_objs = []
+                    for p in particles:
+                        particle_objs += [LHEParticle.fromstring(p)]
+                    yield LHEEvent(eventinfo, particle_objs)
     except ET.ParseError as e:
         print("WARNING. Parse Error:", e)
         return
@@ -214,38 +215,38 @@ def readLHEWithAttributes(filepath):
     Iterate through file, similar to readLHE but also set
     weights and attributes.
     """
-    fileobj = _extract_fileobj(filepath)
     try:
-        for event, element in ET.iterparse(fileobj, events=["end"]):
-            if element.tag == "event":
-                eventdict = {}
-                data = element.text.split("\n")[1:-1]
-                eventdata, particles = data[0], data[1:]
-                eventdict["eventinfo"] = LHEEventInfo.fromstring(eventdata)
-                eventdict["particles"] = []
-                eventdict["weights"] = {}
-                eventdict["attrib"] = element.attrib
-                eventdict["optional"] = []
-                for p in particles:
-                    if not p.strip().startswith("#"):
-                        eventdict["particles"] += [LHEParticle.fromstring(p)]
-                    else:
-                        eventdict["optional"].append(p.strip())
-                for sub in element:
-                    if sub.tag == "rwgt":
-                        for r in sub:
-                            if r.tag == "wgt":
-                                eventdict["weights"][r.attrib["id"]] = float(
-                                    r.text.strip()
-                                )
-                # yield eventdict
-                yield LHEEvent(
-                    eventdict["eventinfo"],
-                    eventdict["particles"],
-                    eventdict["weights"],
-                    eventdict["attrib"],
-                    eventdict["optional"],
-                )
+        with _extract_fileobj(filepath) as fileobj:
+            for event, element in ET.iterparse(fileobj, events=["end"]):
+                if element.tag == "event":
+                    eventdict = {}
+                    data = element.text.split("\n")[1:-1]
+                    eventdata, particles = data[0], data[1:]
+                    eventdict["eventinfo"] = LHEEventInfo.fromstring(eventdata)
+                    eventdict["particles"] = []
+                    eventdict["weights"] = {}
+                    eventdict["attrib"] = element.attrib
+                    eventdict["optional"] = []
+                    for p in particles:
+                        if not p.strip().startswith("#"):
+                            eventdict["particles"] += [LHEParticle.fromstring(p)]
+                        else:
+                            eventdict["optional"].append(p.strip())
+                    for sub in element:
+                        if sub.tag == "rwgt":
+                            for r in sub:
+                                if r.tag == "wgt":
+                                    eventdict["weights"][r.attrib["id"]] = float(
+                                        r.text.strip()
+                                    )
+                    # yield eventdict
+                    yield LHEEvent(
+                        eventdict["eventinfo"],
+                        eventdict["particles"],
+                        eventdict["weights"],
+                        eventdict["attrib"],
+                        eventdict["optional"],
+                    )
     except ET.ParseError:
         print("WARNING. Parse Error.")
         return

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -7,6 +7,8 @@ TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 
 
 def test_gzip_open(tmpdir):
+    assert pylhe._open_gzip_file(TEST_FILE) == TEST_FILE
+
     tmp_path = tmpdir.join("notrealfile.lhe")
     assert pylhe._open_gzip_file(tmp_path) == tmp_path
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -1,3 +1,7 @@
+import gzip
+import os
+from shutil import copyfileobj
+
 import pytest
 import skhep_testdata
 
@@ -8,6 +12,13 @@ TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 
 def test_gzip_open(tmpdir):
     assert pylhe._open_gzip_file(TEST_FILE) == TEST_FILE
+
+    tmp_path = tmpdir.join("pylhe-testfile-pr29.lhe.gz")
+    with open(TEST_FILE, "rb") as readfile:
+        with gzip.open(tmp_path, "wb") as writefile:
+            copyfileobj(readfile, writefile)
+    assert pylhe._open_gzip_file(tmp_path)
+    os.remove(tmp_path)  # Don't keep around even if in /tmp
 
     tmp_path = tmpdir.join("notrealfile.lhe")
     assert pylhe._open_gzip_file(tmp_path) == tmp_path

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -1,7 +1,7 @@
 import gzip
 import os
+import shutil
 from pathlib import Path
-from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -15,13 +15,15 @@ TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 @pytest.fixture(scope="session")
 def testdata_gzip_file():
     test_data = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
+    # Create a tmp path that is named with .gz
     tmp_file = NamedTemporaryFile()
-    tmp_path = Path(tmp_file.name)
+    tmp_path = Path(Path(tmp_file.name).parent.joinpath("pylhe-testfile-pr29.lhe.gz"))
+    shutil.copy(tmp_file.name, tmp_path)
 
-    # create a file that is basically pylhe-testfile-pr29.lhe.gz
+    # create pylhe-testfile-pr29.lhe.gz
     with open(test_data, "rb") as readfile:
         with gzip.open(tmp_path, "wb") as writefile:
-            copyfileobj(readfile, writefile)
+            shutil.copyfileobj(readfile, writefile)
     yield tmp_path
 
     # teardown

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -32,6 +32,11 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
 
     assert pylhe._extract_fileobj(testdata_gzip_file)
 
+    # Needs path-like object, not a fileobj
+    with pytest.raises(TypeError):
+        with open(TEST_FILE, "rb") as readfile:
+            pylhe._extract_fileobj(readfile)
+
     assert isinstance(pylhe._extract_fileobj(TEST_FILE), str)
     assert isinstance(pylhe._extract_fileobj(Path(TEST_FILE)), Path)
     assert isinstance(pylhe._extract_fileobj(testdata_gzip_file), gzip.GzipFile)

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -1,5 +1,3 @@
-import gzip
-
 import pytest
 import skhep_testdata
 
@@ -8,13 +6,13 @@ import pylhe
 TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 
 
-def test_gzip_open_fail(tmpdir):
+def test_gzip_open(tmpdir):
+    tmp_path = tmpdir.join("notrealfile.lhe")
+    assert pylhe._open_gzip_file(tmp_path) == tmp_path
+
     tmp_path = tmpdir.join("notrealfile.lhe.gz")
     tmp_path.write("")
-    print("\n\n")
-    print(tmp_path)
-    print("\n\n")
-    with pytest.raises(OSError, gzip.BadGzipFile):
+    with pytest.raises(OSError):
         pylhe._open_gzip_file(tmp_path)
 
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -17,7 +17,7 @@ def testdata_gzip_file():
     test_data = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
     # Create a tmp path that is named with .gz
     tmp_file = NamedTemporaryFile()
-    tmp_path = Path(Path(tmp_file.name).parent.joinpath("pylhe-testfile-pr29.lhe.gz"))
+    tmp_path = Path(tmp_file.name).parent.joinpath("pylhe-testfile-pr29.lhe.gz")
     shutil.copy(tmp_file.name, tmp_path)
 
     # create pylhe-testfile-pr29.lhe.gz

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -15,16 +15,17 @@ TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 @pytest.fixture(scope="session")
 def testdata_gzip_file():
     test_data = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
-    tmp_path = NamedTemporaryFile()
+    tmp_file = NamedTemporaryFile()
+    tmp_path = Path(tmp_file.name)
 
     # create a file that is basically pylhe-testfile-pr29.lhe.gz
     with open(test_data, "rb") as readfile:
         with gzip.open(tmp_path, "wb") as writefile:
             copyfileobj(readfile, writefile)
-    yield Path(tmp_path.name)
+    yield tmp_path
 
     # teardown
-    os.remove(Path(tmp_path.name))
+    os.remove(tmp_path)
 
 
 def test_gzip_open(tmpdir, testdata_gzip_file):

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -35,13 +35,9 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
 
     assert pylhe._extract_fileobj(testdata_gzip_file)
 
-    tmp_path = tmpdir.join("notrealfile.lhe")
-    assert pylhe._extract_fileobj(tmp_path) == tmp_path
+    assert isinstance(pylhe._extract_fileobj(testdata_gzip_file), gzip.GzipFile)
 
-    tmp_path = tmpdir.join("notrealfile.lhe.gz")
-    tmp_path.write("")
-    with pytest.raises(OSError):
-        pylhe._extract_fileobj(tmp_path)
+    assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
 
 
 def test_event_count():

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -31,17 +31,17 @@ def testdata_gzip_file():
 
 
 def test_gzip_open(tmpdir, testdata_gzip_file):
-    assert pylhe._open_gzip_file(TEST_FILE) == TEST_FILE
+    assert pylhe._extract_gzip_file(TEST_FILE) == TEST_FILE
 
-    assert pylhe._open_gzip_file(testdata_gzip_file)
+    assert pylhe._extract_gzip_file(testdata_gzip_file)
 
     tmp_path = tmpdir.join("notrealfile.lhe")
-    assert pylhe._open_gzip_file(tmp_path) == tmp_path
+    assert pylhe._extract_gzip_file(tmp_path) == tmp_path
 
     tmp_path = tmpdir.join("notrealfile.lhe.gz")
     tmp_path.write("")
     with pytest.raises(OSError):
-        pylhe._open_gzip_file(tmp_path)
+        pylhe._extract_gzip_file(tmp_path)
 
 
 def test_event_count():

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -34,8 +34,8 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
 
     # Needs path-like object, not a fileobj
     with pytest.raises(TypeError):
-        with open(TEST_FILE, "rb") as readfile:
-            pylhe._extract_fileobj(readfile)
+        with open(TEST_FILE, "rb") as fileobj:
+            pylhe._extract_fileobj(fileobj)
 
     assert isinstance(pylhe._extract_fileobj(TEST_FILE), str)
     assert isinstance(pylhe._extract_fileobj(Path(TEST_FILE)), Path)

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -59,3 +59,8 @@ def test_lhe_init():
     assert init_info["PDFsetB"] == pytest.approx(6.0)
     assert init_info["weightingStrategy"] == pytest.approx(7.0)
     assert init_info["numProcesses"] == pytest.approx(8.0)
+
+
+def test_readLHE(testdata_gzip_file):
+    assert pylhe.readLHE(TEST_FILE)
+    assert pylhe.readLHE(testdata_gzip_file)

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -1,8 +1,21 @@
+import gzip
+
 import pytest
-import pylhe
 import skhep_testdata
 
+import pylhe
+
 TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
+
+
+def test_gzip_open_fail(tmpdir):
+    tmp_path = tmpdir.join("notrealfile.lhe.gz")
+    tmp_path.write("")
+    print("\n\n")
+    print(tmp_path)
+    print("\n\n")
+    with pytest.raises(OSError, gzip.BadGzipFile):
+        pylhe._open_gzip_file(tmp_path)
 
 
 def test_event_count():

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -32,7 +32,10 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
 
     assert pylhe._extract_fileobj(testdata_gzip_file)
 
+    assert isinstance(pylhe._extract_fileobj(TEST_FILE), str)
+    assert isinstance(pylhe._extract_fileobj(Path(TEST_FILE)), Path)
     assert isinstance(pylhe._extract_fileobj(testdata_gzip_file), gzip.GzipFile)
+    assert isinstance(pylhe._extract_fileobj(Path(testdata_gzip_file)), gzip.GzipFile)
 
     assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -15,12 +15,9 @@ TEST_FILE = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 @pytest.fixture(scope="session")
 def testdata_gzip_file():
     test_data = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
-    # Create a tmp path that is named with .gz
-    tmp_file = NamedTemporaryFile()
-    tmp_path = Path(tmp_file.name).parent.joinpath("pylhe-testfile-pr29.lhe.gz")
-    shutil.copy(tmp_file.name, tmp_path)
+    tmp_path = Path(NamedTemporaryFile().name)
 
-    # create pylhe-testfile-pr29.lhe.gz
+    # create what is basically pylhe-testfile-pr29.lhe.gz
     with open(test_data, "rb") as readfile:
         with gzip.open(tmp_path, "wb") as writefile:
             shutil.copyfileobj(readfile, writefile)

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -28,8 +28,7 @@ def testdata_gzip_file():
 
 
 def test_gzip_open(tmpdir, testdata_gzip_file):
-    assert pylhe._extract_fileobj(TEST_FILE) == TEST_FILE
-
+    assert pylhe._extract_fileobj(TEST_FILE)
     assert pylhe._extract_fileobj(testdata_gzip_file)
 
     # Needs path-like object, not a fileobj
@@ -37,11 +36,13 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
         with open(TEST_FILE, "rb") as fileobj:
             pylhe._extract_fileobj(fileobj)
 
-    assert isinstance(pylhe._extract_fileobj(TEST_FILE), str)
-    assert isinstance(pylhe._extract_fileobj(Path(TEST_FILE)), Path)
+    with open(TEST_FILE, "rb") as fileobj:
+        assert isinstance(pylhe._extract_fileobj(TEST_FILE), type(fileobj))
+        assert isinstance(pylhe._extract_fileobj(Path(TEST_FILE)), type(fileobj))
     assert isinstance(pylhe._extract_fileobj(testdata_gzip_file), gzip.GzipFile)
     assert isinstance(pylhe._extract_fileobj(Path(testdata_gzip_file)), gzip.GzipFile)
 
+    # Verify uncompressed and compressed both work
     assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
 
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -31,17 +31,17 @@ def testdata_gzip_file():
 
 
 def test_gzip_open(tmpdir, testdata_gzip_file):
-    assert pylhe._extract_gzip_file(TEST_FILE) == TEST_FILE
+    assert pylhe._extract_fileobj(TEST_FILE) == TEST_FILE
 
-    assert pylhe._extract_gzip_file(testdata_gzip_file)
+    assert pylhe._extract_fileobj(testdata_gzip_file)
 
     tmp_path = tmpdir.join("notrealfile.lhe")
-    assert pylhe._extract_gzip_file(tmp_path) == tmp_path
+    assert pylhe._extract_fileobj(tmp_path) == tmp_path
 
     tmp_path = tmpdir.join("notrealfile.lhe.gz")
     tmp_path.write("")
     with pytest.raises(OSError):
-        pylhe._extract_gzip_file(tmp_path)
+        pylhe._extract_fileobj(tmp_path)
 
 
 def test_event_count():


### PR DESCRIPTION
Resolves #65 

```
* Add support for reading gzip-ed files by first opening gzip files if passed in to the readLHE APIs
   - Use _extract_fileobj with a context manager for the readLHE APIs
* Add tests for reading behavior 

Co-authored-by: Lukas <lukas.heinrich@gmail.com>
```