### PR TITLE
fix: Have all read APIs accept gzipped files

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -247,13 +247,15 @@ def readLHEWithAttributes(filepath):
         return
 
 
-def readNumEvents(file):
+def readNumEvents(filepath):
     """
     Moderately efficent way to get the number of events stored in file.
     """
-    return sum(
-        element.tag == "event" for event, element in ET.iterparse(file, events=["end"])
-    )
+    with _extract_fileobj(filepath) as fileobj:
+        return sum(
+            element.tag == "event"
+            for event, element in ET.iterparse(fileobj, events=["end"])
+        )
 
 
 def visualize(event, outputname):

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -42,16 +42,15 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
     assert isinstance(pylhe._extract_fileobj(testdata_gzip_file), gzip.GzipFile)
     assert isinstance(pylhe._extract_fileobj(Path(testdata_gzip_file)), gzip.GzipFile)
 
-    # Verify uncompressed and compressed both work
-    assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
-
 
 def test_event_count(testdata_gzip_file):
     assert pylhe.readNumEvents(TEST_FILE) == 791
-    assert pylhe.readNumEvents(testdata_gzip_file) == 791
+    assert pylhe.readNumEvents(TEST_FILE) == pylhe.readNumEvents(testdata_gzip_file)
 
 
-def test_lhe_init():
+def test_lhe_init(testdata_gzip_file):
+    assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
+
     init_data = pylhe.readLHEInit(TEST_FILE)
     init_info = init_data["initInfo"]
     assert init_info["beamA"] == pytest.approx(1.0)

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -46,8 +46,9 @@ def test_gzip_open(tmpdir, testdata_gzip_file):
     assert pylhe.readLHEInit(TEST_FILE) == pylhe.readLHEInit(testdata_gzip_file)
 
 
-def test_event_count():
+def test_event_count(testdata_gzip_file):
     assert pylhe.readNumEvents(TEST_FILE) == 791
+    assert pylhe.readNumEvents(testdata_gzip_file) == 791
 
 
 def test_lhe_init():


### PR DESCRIPTION
Resolves #79 

```
* Add support for reading gzipped files to pylhe.readNumEvents
* Add test to compare pylhe.readNumEvents output for LHE files and gzipped LHE files
* Amends PR #74
```