### PR TITLE
feat: Use module level __dir__ to restrict public API views

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -7,8 +7,6 @@ import networkx as nx
 import tex2pix
 from particle.converters.bimap import DirectionalMaps
 
-from .awkward import register_awkward, to_akward
-
 __all__ = [
     "LHEEvent",
     "LHEEventInfo",
@@ -16,12 +14,11 @@ __all__ = [
     "LHEInit",
     "LHEParticle",
     "LHEProcInfo",
+    "loads",
     "readLHE",
     "readLHEInit",
     "readLHEWithAttributes",
     "readNumEvents",
-    "register_awkward",
-    "to_akward",
     "visualize",
 ]
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,7 +2,6 @@ import gzip
 import os
 import subprocess
 import xml.etree.ElementTree as ET
-from sys import version_info
 
 import networkx as nx
 import tex2pix
@@ -23,11 +22,10 @@ __all__ = [
     "visualize",
 ]
 
-# Python 3.7+ feature
-if version_info >= (3, 7):
 
-    def __dir__():
-        return __all__
+# Python 3.7+
+def __dir__():
+    return __all__
 
 
 class LHEFile:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -7,6 +7,28 @@ import networkx as nx
 import tex2pix
 from particle.converters.bimap import DirectionalMaps
 
+from .awkward import register_awkward, to_akward
+
+__all__ = [
+    "LHEEvent",
+    "LHEEventInfo",
+    "LHEFile",
+    "LHEInit",
+    "LHEParticle",
+    "LHEProcInfo",
+    "readLHE",
+    "readLHEInit",
+    "readLHEWithAttributes",
+    "readNumEvents",
+    "register_awkward",
+    "to_akward",
+    "visualize",
+]
+
+
+def __dir__():
+    return __all__
+
 
 class LHEFile:
     def __init__(self):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 # Python 3.7+ feature
-if version_info > (3, 6):
+if version_info >= (3, 7):
 
     def __dir__():
         return __all__

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,6 +2,7 @@ import gzip
 import os
 import subprocess
 import xml.etree.ElementTree as ET
+from sys import version_info
 
 import networkx as nx
 import tex2pix
@@ -22,9 +23,11 @@ __all__ = [
     "visualize",
 ]
 
+# Python 3.7+ feature
+if version_info > (3, 6):
 
-def __dir__():
-    return __all__
+    def __dir__():
+        return __all__
 
 
 class LHEFile:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,24 +1,27 @@
 from sys import version_info
 
+import pytest
+
 import pylhe
 
+python37plus_only = pytest.mark.skipif(
+    version_info < (3, 7), reason="requires Python3.7+"
+)
 
+
+@python37plus_only
 def test_top_level_api():
-    if version_info >= (3, 7):
-        assert dir(pylhe) == [
-            "LHEEvent",
-            "LHEEventInfo",
-            "LHEFile",
-            "LHEInit",
-            "LHEParticle",
-            "LHEProcInfo",
-            "loads",
-            "readLHE",
-            "readLHEInit",
-            "readLHEWithAttributes",
-            "readNumEvents",
-            "visualize",
-        ]
-    else:
-        print(dir(pylhe))
-        assert dir(pylhe)
+    assert dir(pylhe) == [
+        "LHEEvent",
+        "LHEEventInfo",
+        "LHEFile",
+        "LHEInit",
+        "LHEParticle",
+        "LHEProcInfo",
+        "loads",
+        "readLHE",
+        "readLHEInit",
+        "readLHEWithAttributes",
+        "readNumEvents",
+        "visualize",
+    ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ import pylhe
 
 
 def test_top_level_api():
-    if version_info > (3, 6):
+    if version_info >= (3, 7):
         assert dir(pylhe) == [
             "LHEEvent",
             "LHEEventInfo",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+import pylhe
+
+
+def test_top_level_api():
+    assert dir(pylhe) == [
+        "LHEEvent",
+        "LHEEventInfo",
+        "LHEFile",
+        "LHEInit",
+        "LHEParticle",
+        "LHEProcInfo",
+        "loads",
+        "readLHE",
+        "readLHEInit",
+        "readLHEWithAttributes",
+        "readNumEvents",
+        "visualize",
+    ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,18 +1,24 @@
+from sys import version_info
+
 import pylhe
 
 
 def test_top_level_api():
-    assert dir(pylhe) == [
-        "LHEEvent",
-        "LHEEventInfo",
-        "LHEFile",
-        "LHEInit",
-        "LHEParticle",
-        "LHEProcInfo",
-        "loads",
-        "readLHE",
-        "readLHEInit",
-        "readLHEWithAttributes",
-        "readNumEvents",
-        "visualize",
-    ]
+    if version_info > (3, 6):
+        assert dir(pylhe) == [
+            "LHEEvent",
+            "LHEEventInfo",
+            "LHEFile",
+            "LHEInit",
+            "LHEParticle",
+            "LHEProcInfo",
+            "loads",
+            "readLHE",
+            "readLHEInit",
+            "readLHEWithAttributes",
+            "readNumEvents",
+            "visualize",
+        ]
+    else:
+        print(dir(pylhe))
+        assert dir(pylhe)


### PR DESCRIPTION
# Description

Implemented from Brett Cannon's blog [An approach to lazy importing in Python 3.7](https://snarky.ca/lazy-importing-in-python-3-7/) and implemented it for `hist` in https://github.com/scikit-hep/hist/pull/179:

> I’ve used Python 3.7 module-level `__getattr__` for a while now to allow mistyping hist.axis import as hist.axes to show a warning but work anyway. However, I completely missed a fantastic usage for Python 3.7 module-level `__dir__ `: you can “fix” IPython’s tab completion to just show the items in `__all__`! Wow! One of the main things that bugged me about importing and defining unrelated things in modules, and one reason that boost-histogram has an `_internal` module.

c.f. https://github.com/scikit-hep/pyhf/issues/1402

Used in PR #83 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use module level __dir__ in combination with __all__ to restrict the public API import views to useful imports
   - Only available in Python 3.7+
* c.f. https://snarky.ca/lazy-importing-in-python-3-7/
* Add tests for output of dir(pylhe)
```
