### PR TITLE
ci: Remove distribution options to enable default build v0.5.0 behavior

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,12 +26,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
+        python -m pip list
     - name: Check MANIFEST
       run: |
         check-manifest
-    - name: Build a binary wheel and a source tarball
+    - name: Build a sdist and a wheel
       run: |
-        python -m build --sdist --wheel --outdir dist/ .
+        python -m build --outdir dist/ .
     - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")


### PR DESCRIPTION
# Description

Remove the option `--sdist --wheel` from 

https://github.com/scikit-hep/pylhe/blob/d35bb3212d8b150c83527bdbf8426b93d6a2ccdd/.github/workflows/publish-package.yml#L32-L34

to enable the default behavior for `build` in release `v0.5.0` of building a sdist and then building a wheel from the sidst to ensure that the sdist is capable of building a wheel. This was added in https://github.com/pypa/build/pull/304

```console
$ pip list | grep build
build       0.5.0
$ python -m build --help
usage: python -m build [-h] [--version] [--sdist] [--wheel] [--outdir OUTDIR] [--skip-dependency-check] [--no-isolation] [--config-setting CONFIG_SETTING] [srcdir]

    A simple, correct PEP 517 package builder.

    By default, a source distribution (sdist) is built from {srcdir}
    and a binary distribution (wheel) is built from the sdist.
    This is recommended as it will ensure the sdist can be used
    to build wheels.

    Pass -s/--sdist and/or -w/--wheel to build a specific distribution.
    If you do this, the default behavior will be disabled, and all
    artifacts will be built from {srcdir} (even if you combine
    -w/--wheel with -s/--sdist, the wheel will be built from {srcdir}).

positional arguments:
  srcdir                source directory (defaults to current directory)

optional arguments:
  -h, --help            show this help message and exit
  --version, -V         show program's version number and exit
  --sdist, -s           build a source distribution (disables the default behavior)
  --wheel, -w           build a wheel (disables the default behavior)
  --outdir OUTDIR, -o OUTDIR
                        output directory (defaults to {srcdir}/dist)
  --skip-dependency-check, -x
                        do not check that build dependencies are installed
  --no-isolation, -n    do not isolate the build in a virtual environment
  --config-setting CONFIG_SETTING, -C CONFIG_SETTING
                        pass options to the backend.  options which begin with a hyphen must be in the form of "--config-setting=--opt(=value)" or "-C--opt(=value)"
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove `--sdist --wheel` from the build CLI options to enable default behavior for build v0.5.0+
   - By default, a source distribution (sdist) is built from {srcdir} and a binary distribution (wheel) is built from the sdist. This is recommended as it will ensure the sdist can be used to build wheels.
   - c.f. https://pypa-build.readthedocs.io/en/stable/changelog.html
* Add pip list to workflow to spot check versions installed
* Update to pypa/gh-action-pypi-publish@v1.4.2
```
