### PR TITLE
chore: Use newer setuptools_scm for versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,8 +3,6 @@ current_version = 0.2.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.cfg]
-
 [bumpversion:file:README.md]
 
 [bumpversion:file:.zenodo.json]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -53,6 +55,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Build Docker image
       run: |
         docker build . --file docker/Dockerfile --tag pylhe/pylhe:$GITHUB_SHA

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src/pylhe/_version.py
 MANIFEST
 build
 dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "src/pyhf/_version.py"
+write_to = "src/pylhe/_version.py"
 local_scheme = "no-local-version"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,11 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = [
-    "wheel",
-    "setuptools>=30.3.0",
-    "attrs>=17.1",
-    "setuptools_scm>=1.15.0",
-    "setuptools_scm_git_archive>=1.0",
-]
+requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/pyhf/_version.py"
+local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ exclude = '''
     \.git
   | .eggs
   | build
+  | src/pylhe/_version.py
 )/
 '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ local_scheme = "no-local-version"
 [tool.black]
 line-length = 88
 include = '\.pyi?$'
-exclude = '''
+extend-exclude = '''
 /(
     \.git
   | .eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pylhe
-version = 0.2.1
 description = small package to get structured data out of Les Houches Event files
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,9 +25,6 @@ classifiers =
     Programming Language :: Python :: 3.9
 
 [options]
-setup_requires =
-    setuptools_scm>=1.15.0
-    setuptools_scm_git_archive>=1.0
 package_dir =
     = src
 packages = find:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -7,9 +7,11 @@ import networkx as nx
 import tex2pix
 from particle.converters.bimap import DirectionalMaps
 
+from ._version import version as __version__
 from .awkward import register_awkward, to_awkward
 
 __all__ = [
+    "__version__",
     "LHEEvent",
     "LHEEventInfo",
     "LHEFile",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,13 +12,13 @@ python37plus_only = pytest.mark.skipif(
 @python37plus_only
 def test_top_level_api():
     assert dir(pylhe) == [
-        "__version__",
         "LHEEvent",
         "LHEEventInfo",
         "LHEFile",
         "LHEInit",
         "LHEParticle",
         "LHEProcInfo",
+        "__version__",
         "loads",
         "read_lhe",
         "read_lhe_init",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,3 +32,7 @@ def test_top_level_api():
 @python37plus_only
 def test_awkward_api():
     assert dir(pylhe.awkward) == ["register_awkward", "to_awkward"]
+
+
+def test_load_version():
+    assert pylhe.__version__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ python37plus_only = pytest.mark.skipif(
 @python37plus_only
 def test_top_level_api():
     assert dir(pylhe) == [
+        "__version__",
         "LHEEvent",
         "LHEEventInfo",
         "LHEFile",


### PR DESCRIPTION
This bumps us up to a more modern version of `setuptools_scm` that supports `pyproject.toml` and will inject the right version at build time (via PEP517/8) as well as generate the corresponding `version.py` for us at build time.

c.f. https://github.com/scikit-hep/pyhf/pull/1450 for motivation

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Update to a modern version of setuptools_scm to support pyproject-based Python packages
   - Use local_scheme = "no-local-version" to continue uploading to TestPyPI
   - c.f. https://github.com/pypa/setuptools_scm/blob/v6.0.1/README.rst#version-number-construction
* Add `pylhe.__version__` to API
* Generate src/pylhe/_version.py at build time
   - Remove setup.cfg from bump2version control
* Set fetch depth:0 in CI to get full history and tags to generate version number
   - c.f. https://github.com/scikit-hep/pyhf/issues/1465
```