### PR TITLE
build: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,6 +45,8 @@ jobs:
         echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
+    - name: List contents of sdist
+      run: tar --list --file dist/pylhe-*.tar.gz
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune **
 graft src
 
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
 prune **
 graft src
 
+include setup.py
+include setup.cfg
 include LICENSE
+include README.md
+include pyproject.toml
+include MANIFEST.in
 
 global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
c.f. https://github.com/scikit-hep/pyhf/pull/1449 for reference and motivation

Needed for PR #94

```
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Add list of sdist contents to package publishing CI
   - Allow for easier checking of the sdist contents in CI logs
```