### PR TITLE
ci: Update CI to test with Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q --no-cache-dir -e .[test]
+        python -m pip --quiet install --editable .[test]
         python -m pip list
+
     - name: Install external pacakges
       run: >-
         sudo apt-get update -y &&
@@ -38,11 +41,13 @@ jobs:
         texlive-latex-base
         texlive-fonts-extra
         texlive-extra-utils
+
     - name: Test with pytest
       run: |
-        python -m pytest -r sx tests/
+        pytest -r sx tests/
+
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --editable .[test]
+        python -m pip --quiet install .[test]
         python -m pip list
 
     - name: Install external pacakges

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,18 +14,22 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.9
+
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q --no-cache-dir -e .[lint]
+        python -m pip --quiet install --editable .[test]
         python -m pip list
+
     - name: Lint with flake8
       run: |
         python -m flake8 .
+
     - name: Lint with Black
       run: |
         black --check --diff --verbose .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --editable .[test]
+        python -m pip --quiet install --editable .[lint]
         python -m pip list
 
     - name: Lint with flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --editable .[lint]
+        python -m pip --quiet install .[lint]
         python -m pip list
 
     - name: Lint with flake8

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,21 +18,26 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.9
+
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
+
     - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
         python -m pip list
+
     - name: Check MANIFEST
       run: |
         check-manifest
+
     - name: Build a sdist and a wheel
       run: |
-        python -m build --outdir dist/ .
+        python -m build .
+
     - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
@@ -43,10 +48,16 @@ jobs:
           return 1
         fi
         echo "python-build named built distribution: ${wheel_name}"
+
     - name: Verify the distribution
       run: twine check dist/*
+
     - name: List contents of sdist
-      run: tar --list --file dist/pylhe-*.tar.gz
+      run: python -m tarfile --list dist/pylhe-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list --file dist/pylhe-*.whl
+
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pylhe'
@@ -54,6 +65,7 @@ jobs:
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe'
       uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -56,7 +56,7 @@ jobs:
       run: python -m tarfile --list dist/pylhe-*.tar.gz
 
     - name: List contents of wheel
-      run: python -m zipfile --list --file dist/pylhe-*.whl
+      run: python -m zipfile --list dist/pylhe-*.whl
 
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master


### PR DESCRIPTION
```
* Add Python 3.10 to testing matrix in CI
   - Use quotes on '3.10' to avoid YAML returning a value of 3.1
* List contents of sdist and wheel during packaging build test
* Use normal installs instead of editable installs for testing
```