### PR TITLE
build: Add Python 3.10 to PyPI metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >=3.6
 install_requires =
     networkx~=2.2
     tex2pix~=0.3
-    particle~=0.16
+    particle~=0.14
     awkward>=1.2.0
     vector>=0.8.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,16 @@ classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
     Intended Audience :: Science/Research
+    Intended Audience :: Developers
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-
+    Programming Language :: Python :: 3.10
 [options]
 package_dir =
     = src
@@ -33,7 +35,7 @@ python_requires = >=3.6
 install_requires =
     networkx~=2.2
     tex2pix~=0.3
-    particle~=0.14
+    particle~=0.16
     awkward>=1.2.0
     vector>=0.8.1
 


### PR DESCRIPTION
Indeed support for Python 3.10 was added in https://github.com/scikit-hep/pylhe/pull/105 but the setup.cfg qualifiers did not reflect that.

While at it I also moved to being more "demanding" on the `Particle` package dependency to ensure that PDG 2021 is used by default, which seems fine (I realise a new version is typically picked up but for formality I made the explicit upgrade).

```
* Add Python 3.10, Python 3 only, and Developers to classifiers
metadata for PyPI.
```