### PR TITLE
chore: Sync pre-commit additional_dependencies and use black-jupyter hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:
-    - id: black
+    - id: black-jupyter
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.2.2
@@ -47,5 +47,3 @@ repos:
       args: ["--py36-plus"]
     - id: nbqa-isort
       additional_dependencies: [isort==5.10.1]
-    - id: nbqa-black
-      additional_dependencies: [black==21.12b0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     rev: 1.2.2
     hooks:
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.29.1]
+      additional_dependencies: [pyupgrade==2.31.0]
       args: ["--py36-plus"]
     - id: nbqa-isort
       additional_dependencies: [isort==5.10.1]


### PR DESCRIPTION
```
* Use black-jupyter hook over nbqa-black
* Sync pre-commit additional_dependencies for pyupgrade
   - Amends PR #107
```