### PR TITLE
build: Require setuptools v42.0.0+ for stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
You need at least setuptools 42 to use pyproject.toml, and attrs is not needed at build time. Also, wheel is declared by PEP 517's get_requires_for_build_sdist, which setuptools declares.