### PR TITLE
build: Set only lower bounds on core dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    networkx~=2.2
-    tex2pix~=0.3
-    particle~=0.14
+    networkx>=2.2
+    tex2pix>=0.3
+    particle>=0.14
     awkward>=1.2.0
     vector>=0.8.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >=3.6
 install_requires =
     networkx>=2.2
     tex2pix>=0.3
-    particle>=0.14
+    particle>=0.16
     awkward>=1.2.0
     vector>=0.8.1
 


### PR DESCRIPTION
c.f. https://github.com/scikit-hep/pyhf/pull/1382 for description of general motivation.

Also updates lower bound on `particle` as originally recommended in PR #108.

```
* Place only lower bounds (>=) on all core dependencies in setup.cfg.
* Update lower bond on particle to v0.16 to ensure compliance with the
2021 version of the PDG.

Co-authored-by: Eduardo Rodrigues <eduardo.rodrigues@cern.ch>
```