### PR TITLE
ci: Report coverage on push and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         pytest -r sx tests/
 
-      # Report coverage for oldest and newest Python tested to deal with version differences
+      # Report coverage for oldest and newest Python tested to guard against version differences
     - name: Report core project coverage with Codecov
       if: >-
         github.event_name != 'schedule' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,16 @@ jobs:
       run: |
         pytest -r sx tests/
 
-    - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      # Report coverage for oldest and newest Python tested to deal with version differences
+    - name: Report core project coverage with Codecov
+      if: >-
+        github.event_name != 'schedule' &&
+        (matrix.python-version == '3.6' || matrix.python-version == '3.10') &&
+        matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
-        flags: unittests
+        files: ./coverage.xml
+        flags: unittests-${{ matrix.python-version }}
         name: pylhe
 
   docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI/CD
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   # Run daily at 0:01 UTC
   schedule:


### PR DESCRIPTION
```
* Report coverage on all triggering GitHub Actions events except
on 'schedule' events.
   - This allows for coverage to be reported on PRs opened from
   outside of scikit-hep.
* Report coverage on oldest and newest Python tested.
* Run CI on push events to 'master'.
```