### PR TITLE
ci: Add semantic PR check GHA workflow

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,0 +1,24 @@
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: semantic-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+
+    name: Validate PR title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR title matches Conventional Commits spec
+        uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As https://github.com/zeke/semantic-pull-requests is no longer maintained and is down (c.f. https://github.com/zeke/semantic-pull-requests/issues/183#issuecomment-1137844183), use the suggested alternative of https://github.com/amannn/action-semantic-pull-request to check that PR titles follow the Conventional Commits spec.

```
* As https://github.com/zeke/semantic-pull-requests is no longer maintained
and is down, use the suggested alternative of
https://github.com/amannn/action-semantic-pull-request to check that PR titles
follow the Conventional Commits spec.
```