### PR TITLE
refactor: Use absolute imports over explicit relative imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
     hooks:
     - id: flake8
 
+-   repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+    - id: absolufy-imports
+
 -   repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -9,8 +9,8 @@ import tex2pix
 from particle import latex_to_html_name
 from particle.converters.bimap import DirectionalMaps
 
-from ._version import version as __version__
-from .awkward import register_awkward, to_awkward
+from pylhe._version import version as __version__
+from pylhe.awkward import register_awkward, to_awkward
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
```
* Change all explicit relative imports to absolute imports.
   - Provides clearer more explicit imports for new developers.
* Add absolufy-imports to pre-commit hooks
```