### PR TITLE
feat: Use tbump over bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 0.2.1
-commit = True
-tag = True
-
-[bumpversion:file:README.md]
-
-[bumpversion:file:.zenodo.json]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require["develop"] = sorted(
     set(
         extras_require["lint"]
         + extras_require["test"]
-        + ["pre-commit", "check-manifest", "bump2version~=1.0", "twine"]
+        + ["pre-commit", "check-manifest", "tbump>=6.7.0", "twine"]
     )
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,45 @@
+github_url = "https://github.com/scikit-hep/pylhe/"
+
+[version]
+current = "0.2.1"
+
+# Example of a semver regexp.
+# Make sure this matches current_version before
+# using tbump
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (rc
+    (?P<candidate>\d+)
+  )?
+  '''
+
+[git]
+# The current version will get updated when tbump is run
+message_template = "Bump version: 0.2.1 → {new_version}"
+tag_template = "v{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "tbump.toml"
+# Restrict search to make it explicit why tbump.toml
+# is even included as a file to bump, as it will get
+# its version.current attribute bumped anyway.
+search = "Bump version: {current_version} → "
+
+[[file]]
+src = "README.md"
+
+[[file]]
+src = ".zenodo.json"
+
+[[field]]
+# the name of the field
+name = "candidate"
+# the default value to use, if there is no match
+default = ""


### PR DESCRIPTION
```
* Add tbump to 'develop' extra and remove bump2version.
* Add tbump.toml to configure tbump.
   - Allow for valid versions to follow SemVer and also support release
candidates: <major>.<minor>.<patch>rc<candidate>
* Remove .bumpversion.cfg.
```