### PR TITLE
feat: more homogeneous usage of ParseError

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -337,17 +337,21 @@ def read_lhe_with_attributes(filepath):
                         eventdict["attrib"],
                         eventdict["optional"],
                     )
-    except ET.ParseError:
-        print("WARNING. Parse Error.")
+    except ET.ParseError as excep:
+        print("WARNING. Parse Error:", excep)
         return
 
 
 def read_num_events(filepath):
     """
-    Moderately efficient way to get the number of events stored in file.
+    Moderately efficient way to get the number of events stored in a file.
     """
-    with _extract_fileobj(filepath) as fileobj:
-        return sum(
-            element.tag == "event"
-            for event, element in ET.iterparse(fileobj, events=["end"])
-        )
+    try:
+        with _extract_fileobj(filepath) as fileobj:
+            return sum(
+                element.tag == "event"
+                for event, element in ET.iterparse(fileobj, events=["end"])
+            )
+    except ET.ParseError as excep:
+        print("WARNING. Parse Error:", excep)
+        return -1


### PR DESCRIPTION
I noticed that the `read_lhe` type of functions and others, which parse the XML, do not all catch parsing errors. This PR makes things more homogeneous. Note that

1. On purpose I am not trying here to deal with test coverage of these parsing errors. That's something to be done with a dedicated PR and will require a special LHE file, if not several.
2.  We should discuss at some point if parsing errors should raise errors or be dealt with smoothly, as now, with print statements. Again, I think it is better to make any modification to the way these errors are dealt with homogeneously across the various methods.