### PR TITLE
build: Support Python 3.7+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     - name: Report core project coverage with Codecov
       if: >-
         github.event_name != 'schedule' &&
-        (matrix.python-version == '3.6' || matrix.python-version == '3.10') &&
+        (matrix.python-version == '3.7' || matrix.python-version == '3.10') &&
         matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v2.38.2
     hooks:
     - id: pyupgrade
+      args: ["--py37-plus"]
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -31,7 +30,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     graphviz>=0.12.0
     particle>=0.16


### PR DESCRIPTION
```
* Require Python 3.7 for install.
* Drop Python 3.6 from testing in CI.
* Enforce Python 3.7+ syntax in pyupgrade.
```

Once Python 3.11 support is added (there is a small bug that can be fixed) and this is merged we could cut `v0.5.0` to get a clean Python version drop on a minor release.