### PR TITLE
ci: Publish to TestPyPI on tag or by workflow dispatch trigger

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,6 +9,13 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  inputs:
+    publish:
+      type: choice
+      description: 'Publish to TestPyPI?'
+      options:
+      - false
+      - true
 
 jobs:
   build-and-publish:
@@ -59,8 +66,11 @@ jobs:
       run: python -m zipfile --list dist/pylhe-*.whl
 
     - name: Publish distribution 📦 to Test PyPI
-      # every PR will trigger a push event on main, so check the push event is actually coming from main
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scikit-hep/pylhe'
+      # Publish to TestPyPI on tag events of if manually triggered
+      # Compare to 'true' string as booleans get turned into strings in the console
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pylhe')
       uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         password: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
Resolves #151

* Publish to TestPyPI on push events where a tag is pushed that starts with a 'v' (release tags of form vX.Y.Z) or on workflow dispatch events where the maintainer running the workflow has selected the 'true' option from the drop-down menu for whether to publish.
   - The workflow dispatch option defaults to 'false' to avoid accidental publishing.
* Update development docs to reflect that not every commit is published to TestPyPI