### PR TITLE
fix: Update KeyError to new exception of DirectionalMap

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -3,7 +3,8 @@ import xml.etree.ElementTree as ET
 
 import graphviz
 from particle import latex_to_html_name
-from particle.converters.bimap import DirectionalMaps, MatchingIDNotFound
+from particle.converters.bimap import DirectionalMaps
+from particle.exceptions import MatchingIDNotFound
 
 from pylhe._version import version as __version__
 from pylhe.awkward import register_awkward, to_awkward

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 
 import graphviz
 from particle import latex_to_html_name
-from particle.converters.bimap import DirectionalMaps
+from particle.converters.bimap import DirectionalMaps, MatchingIDNotFound
 
 from pylhe._version import version as __version__
 from pylhe.awkward import register_awkward, to_awkward
@@ -89,7 +89,7 @@ class LHEEvent:
                 name = _PDGID2LaTeXNameMap[iid]
                 texlbl = f"${name}$"
                 label = f'<<table border="0" cellspacing="0" cellborder="0"><tr><td>{safe_html_name(name)}</td></tr></table>>'
-            except KeyError:
+            except MatchingIDNotFound:
                 texlbl = str(int(p.id))
                 label = f'<<table border="0" cellspacing="0" cellborder="0"><tr><td>{texlbl}</td></tr></table>>'
             self._graph.node(

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -16,7 +16,8 @@ def test_LHEEvent_graph_source():
     assert event.graph.source.count("&#x03c0;") == 8
     assert "<td>p</td>" in event.graph.source
 
-def test_LHEEvent_graph_source_nonstandard_pdg() :
+
+def test_LHEEvent_graph_source_nonstandard_pdg():
     lhe_file = skhep_testdata.data_path("pylhe-testfile-pr180.lhe")
     events = pylhe.read_lhe_with_attributes(lhe_file)
 
@@ -25,7 +26,8 @@ def test_LHEEvent_graph_source_nonstandard_pdg() :
     # building the graph should succeed even though there is
     # a non-standard PDG ID 1023 and the name in the graph
     # source should just be the ID number itself
-    assert event.graph.source.count('1023') == 1
+    assert event.graph.source.count("1023") == 1
+
 
 def test_LHEEvent_graph_render():
     lhe_file = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -16,6 +16,16 @@ def test_LHEEvent_graph_source():
     assert event.graph.source.count("&#x03c0;") == 8
     assert "<td>p</td>" in event.graph.source
 
+def test_LHEEvent_graph_source_nonstandard_pdg() :
+    lhe_file = skhep_testdata.data_path("pylhe-testfile-pr180.lhe")
+    events = pylhe.read_lhe_with_attributes(lhe_file)
+
+    # Get the first event
+    event = next(events)
+    # building the graph should succeed even though there is
+    # a non-standard PDG ID 1023 and the name in the graph
+    # source should just be the ID number itself
+    assert event.graph.source.count('1023') == 1
 
 def test_LHEEvent_graph_render():
     lhe_file = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -26,7 +26,7 @@ def test_LHEEvent_graph_source_nonstandard_pdg():
     # building the graph should succeed even though there is
     # a non-standard PDG ID 1023 and the name in the graph
     # source should just be the ID number itself
-    assert event.graph.source.count("1023") == 1
+    assert event.graph.source.count("<td>1023</td>") == 1
 
 
 def test_LHEEvent_graph_render():


### PR DESCRIPTION
The current code on `main` tries to catch a `KeyError` if a ID is not in the PDG to LaTeX name look up `DirectionalMap`, but the `DirectionalMap` throws a `MatchingIDNotFound` exception when it cannot find an ID.

This bug means that users cannot generate a graph with non-standard PDG IDs in them.

It is a simple patch to fix up this bug and allow for IDs not in the table to simple be represented by their ID number.

**Squash and merge commit message**

```
* Use MatchingIDNotFound exception over KeyError to allow for non-standard PDG
  IDs to be used.
* Add test for handling non-standard PDG IDs.
```