### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       args: ["--py37-plus"]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     - id: isort
 
@@ -41,15 +41,15 @@ repos:
     - id: absolufy-imports
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     - id: black-jupyter
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.0
+    rev: 1.6.1
     hooks:
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==3.3.1]
       args: ["--py37-plus"]
     - id: nbqa-isort
-      additional_dependencies: [isort==5.11.4]
+      additional_dependencies: [isort==5.12.0]


### PR DESCRIPTION
* github.com/pycqa/isort: 5.11.4 → 5.12.0
* github.com/psf/black: 22.12.0 → 23.1.0
* github.com/nbQA-dev/nbQA: 1.6.0 → 1.6.1

As Poetry broke isort and others from even being installed correctly, it is necessary to bump up the pre-commit hooks to newer versions.