### PR TITLE
build: Require Python 3.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
     - name: Report core project coverage with Codecov
       if: >-
         github.event_name != 'schedule' &&
-        (matrix.python-version == '3.7' || matrix.python-version == '3.10') &&
+        (matrix.python-version == '3.8' || matrix.python-version == '3.10') &&
         matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,7 +30,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     graphviz>=0.12.0
     particle>=0.16

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
 ]
 
 
-# Python 3.7+
 def __dir__():
     return __all__
 

--- a/src/pylhe/awkward.py
+++ b/src/pylhe/awkward.py
@@ -4,7 +4,6 @@ import vector
 __all__ = ["register_awkward", "to_awkward"]
 
 
-# Python 3.7+
 def __dir__():
     return __all__
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,15 +1,8 @@
-from sys import version_info
-
 import pytest
 
 import pylhe
 
-python37plus_only = pytest.mark.skipif(
-    version_info < (3, 7), reason="requires Python3.7+"
-)
 
-
-@python37plus_only
 def test_top_level_api():
     assert dir(pylhe) == [
         "LHEEvent",
@@ -28,7 +21,6 @@ def test_top_level_api():
     ]
 
 
-@python37plus_only
 def test_awkward_api():
     assert dir(pylhe.awkward) == ["register_awkward", "to_awkward"]
 


### PR DESCRIPTION
* Drop support for Python 3.7 and require Python 3.8+ for use.
* Remove guard for Python 3.7+ from tests.