### PR TITLE
feat: Add support for POWHEG weights

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require["test"] = sorted(
     {
         "pytest~=6.0",
         "pytest-cov>=2.5.1",
-        "scikit-hep-testdata>=0.4.0",
+        "scikit-hep-testdata>=0.4.36",
         "pydocstyle",
     }
 )

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -324,7 +324,7 @@ def read_lhe_with_attributes(filepath):
                             eventdict["optional"].append(p.strip())
                     for sub in element:
                         if sub.tag == "weights":
-                            for i,w in enumerate(sub.text.splitlines()):
+                            for i,w in enumerate(sub.text.split()):
                                 if w:
                                     eventdict["weights"][i] = float(w)
                         if sub.tag == "rwgt":

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -307,7 +307,17 @@ def read_lhe(filepath):
 
 def _get_index_to_id_map(init):
     """
-    Convert index to id.
+    Produce a dictionary to map weight indices to the id of the weight.
+
+    It is used for LHE files where there is only a list of weights per event.
+    This dictionary is then used to map the list of weights to their weight id.
+    Ideally, this needs to be done only once and the dictionary can be reused.
+
+    Args:
+        init (dict): init block as returned by read_lhe_init
+
+    Returns:
+        dict: {weight index: weight id}
     """
     ret = {}
     for wg in init["weightgroup"].values():

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -270,8 +270,6 @@ def read_lhe_init(filepath):
                             try:
                                 wg_id = w.attrib["id"]
                             except KeyError:
-                                # Instead of raising an error, we could just use the index
-                                # wg_id = index
                                 print("weight must have attribute 'id'")
                                 raise
                             _temp["weights"][wg_id] = {

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -323,6 +323,10 @@ def read_lhe_with_attributes(filepath):
                         else:
                             eventdict["optional"].append(p.strip())
                     for sub in element:
+                        if sub.tag == "weights":
+                            for i,w in enumerate(sub.text.splitlines()):
+                                if w:
+                                    eventdict["weights"][i] = float(w)
                         if sub.tag == "rwgt":
                             for r in sub:
                                 if r.tag == "wgt":

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -277,7 +277,7 @@ def read_lhe_init(filepath):
                             _temp["weights"][wg_id] = {
                                 "attrib": w.attrib,
                                 "name": w.text.strip(),
-                                "index" : index,
+                                "index": index,
                             }
                             index += 1
 
@@ -304,13 +304,14 @@ def read_lhe(filepath):
         print("WARNING. Parse Error:", excep)
         return
 
+
 def _get_index_to_id_map(init):
     """
     Convert index to id.
     """
     ret = {}
     for wg in init["weightgroup"].values():
-        for id,w in wg["weights"].items():
+        for id, w in wg["weights"].items():
             ret[w["index"]] = id
             # ret[w["index"]] = w["attrib"]["id"]
     return ret
@@ -321,7 +322,7 @@ def read_lhe_with_attributes(filepath):
     Iterate through file, similar to read_lhe but also set
     weights and attributes.
     """
-    index_map= None
+    index_map = None
     try:
         with _extract_fileobj(filepath) as fileobj:
             for event, element in ET.iterparse(fileobj, events=["end"]):
@@ -342,7 +343,9 @@ def read_lhe_with_attributes(filepath):
                     for sub in element:
                         if sub.tag == "weights":
                             if not index_map:
-                                index_map = _get_index_to_id_map(read_lhe_init(filepath))
+                                index_map = _get_index_to_id_map(
+                                    read_lhe_init(filepath)
+                                )
                             for i, w in enumerate(sub.text.split()):
                                 if w:
                                     eventdict["weights"][index_map[i]] = float(w)

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -324,7 +324,7 @@ def read_lhe_with_attributes(filepath):
                             eventdict["optional"].append(p.strip())
                     for sub in element:
                         if sub.tag == "weights":
-                            for i,w in enumerate(sub.text.split()):
+                            for i, w in enumerate(sub.text.split()):
                                 if w:
                                     eventdict["weights"][i] = float(w)
                         if sub.tag == "rwgt":

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -270,7 +270,7 @@ def read_lhe_init(filepath):
                             try:
                                 wg_id = w.attrib["id"]
                             except KeyError:
-                                # Instead of raising an error, we just use the index
+                                # Instead of raising an error, we could just use the index
                                 # wg_id = index
                                 print("weight must have attribute 'id'")
                                 raise

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -321,7 +321,6 @@ def _get_index_to_id_map(init):
     for wg in init["weightgroup"].values():
         for id, w in wg["weights"].items():
             ret[w["index"]] = id
-            # ret[w["index"]] = w["attrib"]["id"]
     return ret
 
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -158,7 +158,7 @@ def test_read_lhe_powheg(file):
 @pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_with_attributes_powheg(file):
     """
-    Test method read_lhe_with_attributes() on a LesHouchesEvents POWHEG file.
+    Test method read_lhe_with_attributes() on a LesHouchesEvents POWHEG files.
     """
     events = pylhe.read_lhe_with_attributes(file)
 
@@ -170,7 +170,7 @@ def test_read_lhe_with_attributes_powheg(file):
 @pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_powheg(file):
     """
-    Test method read_lhe() on a LesHouchesEvents POWHEG file.
+    Test method read_lhe() on a LesHouchesEvents POWHEG files.
     """
     events = pylhe.read_lhe(file)
 
@@ -180,7 +180,9 @@ def test_read_lhe_powheg(file):
 
 
 def test_read_lhe_initrwgt_weights_v3():
-    """ """
+    """
+    Test the weights from initrwgt with a weights list. 
+    """
     events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_INITRWGT_WEIGHTS)
 
     assert events
@@ -190,7 +192,9 @@ def test_read_lhe_initrwgt_weights_v3():
 
 
 def test_read_lhe_rwgt_wgt_v3():
-    """ """
+    """
+    Test the weights from rwgt with a wgt list.
+    """
     events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_RWGT_WGT)
 
     assert events

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -146,7 +146,7 @@ def test_read_lhe_with_attributes_v3():
 @pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_powheg(file):
     """
-    Test method read_lhe() on a LesHouchesEvents POWHEG file.
+    Test method read_lhe() on several types of LesHouchesEvents POWHEG files.
     """
     events = pylhe.read_lhe(file)
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -12,9 +12,14 @@ from pylhe import LHEEvent
 
 TEST_FILE_LHE_v1 = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 TEST_FILE_LHE_v3 = skhep_testdata.data_path("pylhe-testlhef3.lhe")
-TEST_FILE_LHE_INITRWGT_WEIGHTS = skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-hvq.lhe")
-TEST_FILE_LHE_RWGT_WGT= skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-W.lhe")
-TEST_FILES_LHE_POWHEG = [skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-%s.lhe"%(proc)) for proc in ["Z", "W", "Zj", "trijet","directphoton", "hvq"]]
+TEST_FILE_LHE_INITRWGT_WEIGHTS = skhep_testdata.data_path(
+    "pylhe-testfile-powheg-box-v2-hvq.lhe"
+)
+TEST_FILE_LHE_RWGT_WGT = skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-W.lhe")
+TEST_FILES_LHE_POWHEG = [
+    skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-%s.lhe" % (proc))
+    for proc in ["Z", "W", "Zj", "trijet", "directphoton", "hvq"]
+]
 
 
 @pytest.fixture(scope="session")
@@ -138,7 +143,7 @@ def test_read_lhe_with_attributes_v3():
         assert isinstance(e, LHEEvent)
 
 
-@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+@pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_powheg(file):
     """
     Test method read_lhe() on a LesHouchesEvents POWHEG file.
@@ -149,7 +154,8 @@ def test_read_lhe_powheg(file):
     for e in events:
         assert isinstance(e, LHEEvent)
 
-@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+
+@pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_with_attributes_powheg(file):
     """
     Test method read_lhe_with_attributes() on a LesHouchesEvents POWHEG file.
@@ -160,7 +166,8 @@ def test_read_lhe_with_attributes_powheg(file):
     for e in events:
         assert isinstance(e, LHEEvent)
 
-@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+
+@pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_powheg(file):
     """
     Test method read_lhe() on a LesHouchesEvents POWHEG file.
@@ -171,9 +178,9 @@ def test_read_lhe_powheg(file):
     for e in events:
         assert isinstance(e, LHEEvent)
 
+
 def test_read_lhe_initrwgt_weights_v3():
-    """
-    """
+    """ """
     events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_INITRWGT_WEIGHTS)
 
     assert events
@@ -181,15 +188,16 @@ def test_read_lhe_initrwgt_weights_v3():
         assert isinstance(e, LHEEvent)
         assert len(e.weights) > 0
 
+
 def test_read_lhe_rwgt_wgt_v3():
-    """
-    """
+    """ """
     events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_RWGT_WGT)
 
     assert events
     for e in events:
         assert isinstance(e, LHEEvent)
         assert len(e.weights) > 0
+
 
 def test_issue_102():
     """

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -158,7 +158,7 @@ def test_read_lhe_powheg(file):
 @pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
 def test_read_lhe_with_attributes_powheg(file):
     """
-    Test method read_lhe_with_attributes() on a LesHouchesEvents POWHEG files.
+    Test method read_lhe_with_attributes() on several types of LesHouchesEvents POWHEG files.
     """
     events = pylhe.read_lhe_with_attributes(file)
 

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -167,18 +167,6 @@ def test_read_lhe_with_attributes_powheg(file):
         assert isinstance(e, LHEEvent)
 
 
-@pytest.mark.parametrize("file", TEST_FILES_LHE_POWHEG)
-def test_read_lhe_powheg(file):
-    """
-    Test method read_lhe() on a LesHouchesEvents POWHEG files.
-    """
-    events = pylhe.read_lhe(file)
-
-    assert events
-    for e in events:
-        assert isinstance(e, LHEEvent)
-
-
 def test_read_lhe_initrwgt_weights():
     """
     Test the weights from initrwgt with a weights list.

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -12,6 +12,9 @@ from pylhe import LHEEvent
 
 TEST_FILE_LHE_v1 = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
 TEST_FILE_LHE_v3 = skhep_testdata.data_path("pylhe-testlhef3.lhe")
+TEST_FILE_LHE_INITRWGT_WEIGHTS = skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-hvq.lhe")
+TEST_FILE_LHE_RWGT_WGT= skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-W.lhe")
+TEST_FILES_LHE_POWHEG = [skhep_testdata.data_path("pylhe-testfile-powheg-box-v2-%s.lhe"%(proc)) for proc in ["Z", "W", "Zj", "trijet","directphoton", "hvq"]]
 
 
 @pytest.fixture(scope="session")
@@ -134,6 +137,59 @@ def test_read_lhe_with_attributes_v3():
     for e in events:
         assert isinstance(e, LHEEvent)
 
+
+@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+def test_read_lhe_powheg(file):
+    """
+    Test method read_lhe() on a LesHouchesEvents POWHEG file.
+    """
+    events = pylhe.read_lhe(file)
+
+    assert events
+    for e in events:
+        assert isinstance(e, LHEEvent)
+
+@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+def test_read_lhe_with_attributes_powheg(file):
+    """
+    Test method read_lhe_with_attributes() on a LesHouchesEvents POWHEG file.
+    """
+    events = pylhe.read_lhe_with_attributes(file)
+
+    assert events
+    for e in events:
+        assert isinstance(e, LHEEvent)
+
+@pytest.mark.parametrize('file', TEST_FILES_LHE_POWHEG)
+def test_read_lhe_powheg(file):
+    """
+    Test method read_lhe() on a LesHouchesEvents POWHEG file.
+    """
+    events = pylhe.read_lhe(file)
+
+    assert events
+    for e in events:
+        assert isinstance(e, LHEEvent)
+
+def test_read_lhe_initrwgt_weights_v3():
+    """
+    """
+    events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_INITRWGT_WEIGHTS)
+
+    assert events
+    for e in events:
+        assert isinstance(e, LHEEvent)
+        assert len(e.weights) > 0
+
+def test_read_lhe_rwgt_wgt_v3():
+    """
+    """
+    events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_RWGT_WGT)
+
+    assert events
+    for e in events:
+        assert isinstance(e, LHEEvent)
+        assert len(e.weights) > 0
 
 def test_issue_102():
     """

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -178,6 +178,7 @@ def test_read_lhe_powheg(file):
     for e in events:
         assert isinstance(e, LHEEvent)
 
+
 def test_read_lhe_initrwgt_weights():
     """
     Test the weights from initrwgt with a weights list.
@@ -188,6 +189,7 @@ def test_read_lhe_initrwgt_weights():
     for e in events:
         assert isinstance(e, LHEEvent)
         assert len(e.weights) > 0
+
 
 def test_read_lhe_rwgt_wgt():
     """

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -178,8 +178,7 @@ def test_read_lhe_powheg(file):
     for e in events:
         assert isinstance(e, LHEEvent)
 
-
-def test_read_lhe_initrwgt_weights_v3():
+def test_read_lhe_initrwgt_weights():
     """
     Test the weights from initrwgt with a weights list.
     """
@@ -190,8 +189,7 @@ def test_read_lhe_initrwgt_weights_v3():
         assert isinstance(e, LHEEvent)
         assert len(e.weights) > 0
 
-
-def test_read_lhe_rwgt_wgt_v3():
+def test_read_lhe_rwgt_wgt():
     """
     Test the weights from rwgt with a wgt list.
     """

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -181,7 +181,7 @@ def test_read_lhe_powheg(file):
 
 def test_read_lhe_initrwgt_weights_v3():
     """
-    Test the weights from initrwgt with a weights list. 
+    Test the weights from initrwgt with a weights list.
     """
     events = pylhe.read_lhe_with_attributes(TEST_FILE_LHE_INITRWGT_WEIGHTS)
 


### PR DESCRIPTION
powheg uses plain text weights in lhe, like: 

```
<event>
      7  10001  1.11453E+07  2.42132E+00 -1.00000E+00  3.21830E-01
      -2    -1     0     0     0   502  0.000000000E+00  0.000000000E+00  1.596673772E-01  1.596673772E-01  0.000000000E+00  0.00000E+00  9.000E+00
      21    -1     0     0   502   501  0.000000000E+00  0.000000000E+00 -1.979087573E+01  1.979087573E+01  0.000000000E+00  0.00000E+00  9.000E+00
      23     2     1     2     0     0 -2.715131942E-01 -6.004246500E-01 -3.272239123E+00  3.504354871E+00  1.067110589E+00  0.00000E+00  9.000E+00
      11     1     3     3     0     0 -9.921110112E-02  2.574546034E-01 -3.072708859E-01  4.129665530E-01  5.110000000E-04  0.00000E+00  9.000E+00
     -11     1     3     3     0     0 -1.723020930E-01 -8.578792534E-01 -2.964968237E+00  3.091388318E+00  5.110000000E-04  0.00000E+00  9.000E+00
      -2     1     1     2     0   511 -3.204270527E-01  4.049849988E-01 -1.767181124E+00  1.841090837E+00  0.000000000E+00  0.00000E+00  9.000E+00
      21     1     1     2   511   501  5.919402469E-01  1.954396512E-01 -1.459178811E+01  1.460509740E+01  1.685873940E-07  0.00000E+00  9.000E+00
#rwgt            2         101   3933017.7360749426                3         267           0
<weights>
0.11148E+08
0.11098E+08
0.10961E+08
0.13534E+08
0.87849E+07
0.91411E+07
0.13910E+08
0.11218E+08
0.11076E+08
0.10925E+08
0.10971E+08
0.10997E+08
0.11103E+08
0.10964E+08
0.10974E+08
0.11205E+08
0.11144E+08
0.11317E+08
0.11325E+08
0.11321E+08
0.11305E+08
0.11320E+08
0.11363E+08
0.11194E+08
0.11332E+08
0.11284E+08
0.11069E+08
0.11289E+08
0.11223E+08
0.11280E+08
0.11332E+08
0.11131E+08
0.11219E+08
0.11152E+08
0.11150E+08
0.11264E+08
0.11044E+08
0.10938E+08
0.11302E+08
0.11118E+08
0.11175E+08
0.11155E+08
0.11140E+08
0.11353E+08
0.10951E+08
</weights>
</event>
```
[pwgevents-0001.lhe.zip](https://github.com/scikit-hep/pylhe/files/13674230/pwgevents-0001.lhe.zip)


```
* Add support for reading POWHEG weights.
* Add tests for POWHEG.
   - Update scikit-hep-testdata test dependency to include
     version with POWHEG file.
```
