### PR TITLE
fix: dict classes should produce instances of themselves

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -185,12 +185,12 @@ class LHEInit(dict):
         "numProcesses",
     ]
 
-    def __init__(self):
-        pass
+    def __init__(self,*args,**kwargs):
+        super().__init__(*args,**kwargs)
 
     @classmethod
     def fromstring(cls, string):
-        return dict(zip(cls.fieldnames, map(float, string.split())))
+        return cls(**dict(zip(cls.fieldnames, map(float, string.split()))))
 
 
 class LHEProcInfo(dict):
@@ -198,12 +198,12 @@ class LHEProcInfo(dict):
 
     fieldnames = ["xSection", "error", "unitWeight", "procId"]
 
-    def __init__(self):
-        pass
+    def __init__(self,*args,**kwargs):
+        super().__init__(*args,**kwargs)
 
     @classmethod
     def fromstring(cls, string):
-        return dict(zip(cls.fieldnames, map(float, string.split())))
+        return cls(**dict(zip(cls.fieldnames, map(float, string.split()))))
 
 
 def _extract_fileobj(filepath):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -185,8 +185,8 @@ class LHEInit(dict):
         "numProcesses",
     ]
 
-    def __init__(self,*args,**kwargs):
-        super().__init__(*args,**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def fromstring(cls, string):
@@ -198,8 +198,8 @@ class LHEProcInfo(dict):
 
     fieldnames = ["xSection", "error", "unitWeight", "procId"]
 
-    def __init__(self,*args,**kwargs):
-        super().__init__(*args,**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def fromstring(cls, string):


### PR DESCRIPTION
`LHEInit` and `LHEProcInfo` inherit from `dict`. When parsing a string to either of them with `fromstring` it should return the corresponding class not a generic dict. They should have the same `__init__` function as a `dict` for convenience.

```
* `LHEInit` and `LHEProcInfo` inherit from `dict`. When parsing a string
  to either of them with `fromstring` it should return the corresponding
  class not a generic dict. They should have the same `__init__` function
  as a `dict` for convenience.
```