### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -185,8 +185,9 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tbump
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system tbump
         python -m pip list
 
     - name: Setup Git user to push new tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install .[test]
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --quiet install '.[test]'
         python -m pip list
 
     - name: Install external packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system --quiet install '.[test]'
+        uv pip install --system --quiet '.[test]'
         python -m pip list
 
     - name: Install external packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system --quiet install '.[lint]'
+        uv pip install --system --quiet '.[lint]'
         python -m pip list
 
     - name: Lint with flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install .[lint]
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --quiet install '.[lint]'
         python -m pip list
 
     - name: Lint with flake8

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -40,8 +40,9 @@ jobs:
 
     - name: Install python-build, check-manifest, and twine
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install build check-manifest twine
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system build check-manifest twine
         python -m pip list
 
     - name: Check MANIFEST

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/* && \
     cd /code && \
-    python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir . && \
+    python -m pip install uv && \
+    uv pip install --system --upgrade --no-cache pip setuptools wheel && \
+    uv pip install --system --no-cache . && \
     python -m pip list
 
 FROM base


### PR DESCRIPTION
* Use 'uv pip install --system' in CI to speed up installs.