### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,6 +31,9 @@ jobs:
   build:
     name: Build Python distribution
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
     - uses: actions/checkout@v4
@@ -51,7 +54,7 @@ jobs:
 
     - name: Build a sdist and a wheel
       run: |
-        python -m build .
+        python -m build --installer uv .
 
     - name: Verify history available for dev versions
       run: |
@@ -72,6 +75,16 @@ jobs:
 
     - name: List contents of wheel
       run: python -m zipfile --list dist/pylhe-*.whl
+
+    - name: Generate artifact attestation for sdist and wheel
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe')
+      uses: actions/attest-build-provenance@310b0a4a3b0b78ef57ecda988ee04b132db73ef8 # v1.4.1
+      with:
+        subject-path: "dist/pylhe-*"
 
     - name: Upload distribution artifact
       uses: actions/upload-artifact@v4
@@ -101,6 +114,26 @@ jobs:
 
     - name: List all files
       run: ls -lh dist
+
+    - name: Verify sdist artifact attestation
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/pylhe-*.tar.gz --repo ${{ github.repository }}
+
+    - name: Verify wheel artifact attestation
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pylhe')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pylhe')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/pylhe-*.whl --repo ${{ github.repository }}
 
     - name: Publish distribution 📦 to Test PyPI
       # Publish to TestPyPI on tag events of if manually triggered

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "scikit-hep-testdata>=0.4.36",
 ]
 develop = [
-    "pyhf[lint,test]",
+    "pylhe[lint,test]",
     "pre-commit",
     "tbump>=6.7.0",
 ]


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing to PyPI using the 'gh attestation verify' CLI API, added in v2.49.0.
   - c.f. https://github.com/cli/cli/releases/tag/v2.49.0