### PR TITLE
ci: Use 'pipx run' to simplify installs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,17 +27,10 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install uv
-        uv pip install --system --upgrade pip wheel
-        uv pip install --system --quiet '.[lint]'
-        python -m pip list
-
     - name: Lint with flake8
       run: |
-        python -m flake8 .
+        pipx run flake8 .
 
     - name: Lint with Black
       run: |
-        black --check --diff --verbose .
+        pipx run black --check --diff --verbose .

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,16 +45,9 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install python-build, and twine
-      run: |
-        python -m pip install uv
-        uv pip install --system --upgrade pip wheel
-        uv pip install --system build twine
-        python -m pip list
-
     - name: Build a sdist and a wheel
       run: |
-        python -m build --installer uv .
+        pipx run build --installer uv .
 
     - name: Verify history available for dev versions
       run: |
@@ -68,7 +61,7 @@ jobs:
         echo "python-build named built distribution: ${wheel_name}"
 
     - name: Verify the distribution
-      run: twine check --strict dist/*
+      run: pipx run twine check --strict dist/*
 
     - name: List contents of sdist
       run: python -m tarfile --list dist/pylhe-*.tar.gz

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,6 +45,10 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install dependencies
+      run: |
+        python -m pip install uv
+
     - name: Build a sdist and a wheel
       run: |
         pipx run build --installer uv .


### PR DESCRIPTION
* Use 'pipx run' to avoid having to install tools into the same environment.