### PR TITLE
docs: Add CITATION.cff Citation File Format file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-    "description": "small package to get structured data out of Les Houches Event files",
+    "description": "A small package to get structured data out of Les Houches Event files",
     "license": "Apache-2.0",
     "title": "scikit-hep/pylhe: v0.8.0",
     "version": "v0.8.0",
@@ -23,8 +23,10 @@
     ],
     "access_right": "open",
     "keywords": [
+      "lhe",
       "physics",
-      "lhe"
+      "python",
+      "scikit-hep",
     ],
     "related_identifiers": [
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,7 +26,7 @@
       "lhe",
       "physics",
       "python",
-      "scikit-hep",
+      "scikit-hep"
     ],
     "related_identifiers": [
         {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+authors:
+- family-names: "Heinrich"
+  given-names: "Lukas"
+  orcid: "https://orcid.org/0000-0002-4048-7584"
+  affiliation: "Technical University of Munich"
+- family-names: "Feickert"
+  given-names: "Matthew"
+  orcid: "https://orcid.org/0000-0003-4124-7862"
+  affiliation: "University of Wisconsin-Madison"
+- family-names: "Rodrigues"
+  given-names: "Eduardo"
+  orcid: "https://orcid.org/0000-0003-2846-7625"
+  affiliation: "University of Liverpool"
+title: "pylhe: v0.8.0"
+version: 0.8.0
+doi: 10.5281/zenodo.1217031
+repository-code: "https://github.com/scikit-hep/pylhe/releases/tag/v0.8.0"
+keywords:
+  - lhe
+  - physics
+  - python
+  - scikit-hep
+license: "Apache-2.0"
+abstract: |
+  A small package to get structured data out of Les Houches Event files.

--- a/tbump.toml
+++ b/tbump.toml
@@ -38,6 +38,9 @@ src = "README.md"
 [[file]]
 src = ".zenodo.json"
 
+[[file]]
+src = "CITATION.cff"
+
 [[field]]
 # the name of the field
 name = "candidate"


### PR DESCRIPTION
* Add Citation File Format file to repo to get repository cite button on GitHub.
   - c.f. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files
* Add CITATION.cff to tbump control.