### PR TITLE
docs: Add Alexander Puck Neuwirth as maintainer

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -19,6 +19,11 @@
             "affiliation": "University of Liverpool",
             "name": "Eduardo Rodrigues",
             "orcid": "0000-0003-2846-7625"
+        },
+        {
+            "affiliation": "Institut für Theoretische Physik, Universität Münster",
+            "name": "Alexander Puck Neuwirth",
+            "orcid": "0000-0002-2484-1328"
         }
     ],
     "access_right": "open",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,10 @@ authors:
   given-names: "Eduardo"
   orcid: "https://orcid.org/0000-0003-2846-7625"
   affiliation: "University of Liverpool"
+- family-names: "Neuwirth"
+  given-names: "Alexander Puck"
+  orcid: "https://orcid.org/0000-0002-2484-1328"
+  affiliation: "Institut für Theoretische Physik, Universität Münster"
 title: "pylhe: v0.9.0"
 version: 0.9.0
 doi: 10.5281/zenodo.1217031

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The preferred BibTeX entry for citation of `pylhe` is
 
 ```
 @software{pylhe,
-  author = {Lukas Heinrich and Matthew Feickert and Eduardo Rodrigues},
+  author = {Lukas Heinrich and Matthew Feickert and Eduardo Rodrigues and Alexander Puck Neuwirth},
   title = "{pylhe: v0.9.0}",
   version = {v0.9.0},
   doi = {10.5281/zenodo.1217031},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
     { name = "Lukas Heinrich", email = "lukas.heinrich@cern.ch" },
     { name = "Matthew Feickert", email = "matthew.feickert@cern.ch" },
     { name = "Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch" },
+    { name = "Alexander Puck Neuwirth", email = "a_neuw01@uni-muenster.de" },
 ]
 maintainers = [ {name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com"} ]
 keywords = [


### PR DESCRIPTION
* Add Alexander Puck Neuwirth as a project maintainer and add him to the author lists.