### PR TITLE
fix: Add missing comma in LHEInit fieldnames

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -248,7 +248,7 @@ def _indent(elem, level=0):
 class LHEInit(dict):
     """Store the <init> block as dict."""
 
-    fieldnames = ["initInfo", "procInfo" "weightgroup", "LHEVersion"]
+    fieldnames = ["initInfo", "procInfo", "weightgroup", "LHEVersion"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Fixes the bug in Issue #281 

Not sure we have a good test at the moment though.