### PR TITLE
fix: memory increase

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -597,7 +597,7 @@ def read_num_events(filepath):
     """
     try:
         with _extract_fileobj(filepath) as fileobj:
-            context = ET.iterparse(fileobj, events=["end"])
+            context = ET.iterparse(fileobj, events=["start", "end"])
             _, root = next(context)  # Get the root element
             count = 0
             for event, element in context:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -504,6 +504,8 @@ def read_lhe(filepath):
                     particles = particles[: int(eventinfo.nparticles)]
                     particle_objs = [LHEParticle.fromstring(p) for p in particles]
                     yield LHEEvent(eventinfo, particle_objs)
+                # Clear the element to free memory
+                element.clear()
     except ET.ParseError as excep:
         print("WARNING. Parse Error:", excep)
         return
@@ -576,6 +578,8 @@ def read_lhe_with_attributes(filepath):
                         eventdict["attrib"],
                         eventdict["optional"],
                     )
+                    # Clear processed elements
+                    element.clear()
     except ET.ParseError as excep:
         print("WARNING. Parse Error:", excep)
         return
@@ -587,10 +591,13 @@ def read_num_events(filepath):
     """
     try:
         with _extract_fileobj(filepath) as fileobj:
-            return sum(
-                element.tag == "event"
-                for event, element in ET.iterparse(fileobj, events=["end"])
-            )
+            count = 0
+            for _event, element in ET.iterparse(fileobj, events=["end"]):
+                if element.tag == "event":
+                    count += 1
+                # Clear the element to free memory
+                element.clear()
+            return count
     except ET.ParseError as excep:
         print("WARNING. Parse Error:", excep)
         return -1

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -508,6 +508,7 @@ def read_lhe(filepath):
                     yield LHEEvent(eventinfo, particle_objs)
                     # Clear the element to free memory
                     element.clear()
+                    # Root tracks sub-elements -> clear all sub-elements
                     root.clear()
     except ET.ParseError as excep:
         print("WARNING. Parse Error:", excep)
@@ -585,6 +586,7 @@ def read_lhe_with_attributes(filepath):
                     )
                     # Clear processed elements
                     element.clear()
+                    # Root tracks sub-elements -> clear all sub-elements
                     root.clear()
     except ET.ParseError as excep:
         print("WARNING. Parse Error:", excep)
@@ -605,6 +607,7 @@ def read_num_events(filepath):
                     count += 1
                     # Clear the element to free memory
                     element.clear()
+                    # Root tracks sub-elements -> clear all sub-elements
                     root.clear()
             return count
     except ET.ParseError as excep:

--- a/tests/test_lhe_reader.py
+++ b/tests/test_lhe_reader.py
@@ -293,3 +293,99 @@ def test_read_lhe_init_raises():
 </initrwgt>
 </init>"""
         )
+
+
+def test_event_at_position_5():
+    """
+    Test that the event at position 5 has the expected values.
+    The element at position 5 in the LHE file is:
+
+    <event>
+         5     0  1.554392E-03  0.000000E+00  0.000000E+00  0.000000E+00
+         111    0    0    0    0    0 -9.7035523745E-01 -9.8435906372E-01  5.1424008917E+00  5.3267140888E+00  1.3800000000E-01 0. 9.
+         211    0    0    0    0    0 -2.1024089632E-01 -3.2883303721E-02  3.1406432734E+00  3.1508676134E+00  1.3800000000E-01 0. 9.
+        -211    0    0    0    0    0  3.9695103971E-02 -2.2872518121E-01  1.0496526207E-01  2.8974577830E-01  1.3800000000E-01 0. 9.
+        2212    0    0    0    0    0 -8.6160811751E-01 -7.3819273849E-01  7.4246467306E+00  7.5762050386E+00  9.9307937557E-01 0. 9.
+         211    0    0    0    0    0 -4.7889071830E-01 -2.8340027352E-01  1.5195379346E+00  1.6240971553E+00  1.3800000000E-01 0. 9.
+    # 5    34  1.5543917618E-03   3.6288856778E+01  0.0000000000E+00  0.0000000000E+00  3.6288856778E+01   1.9388062018E+01  2.3242767182E+00  2.1256769904E+00  1.9130504008E+01   9.0374892691E-01 -1.4114
+    </event>
+    """
+    events = pylhe.read_lhe(TEST_FILE_LHE_v1)
+
+    # Get the event at position 5 (0-indexed)
+    target_event = None
+    for i, event in enumerate(events):
+        if i == 5:
+            target_event = event
+            break
+
+    assert target_event is not None, "Event at position 5 should exist"
+
+    # Test event info values from the LHE format comment
+    assert target_event.eventinfo.nparticles == pytest.approx(5.0)
+    assert target_event.eventinfo.pid == pytest.approx(0.0)
+    assert target_event.eventinfo.weight == pytest.approx(1.554392e-03)
+    assert target_event.eventinfo.scale == pytest.approx(0.0)
+    assert target_event.eventinfo.aqed == pytest.approx(0.0)
+    assert target_event.eventinfo.aqcd == pytest.approx(0.0)
+
+    # Test that we have the expected number of particles
+    assert len(target_event.particles) == 5
+
+    # Test particle properties based on the LHE event data
+    # First particle: 111 (pi0)
+    first_particle = target_event.particles[0]
+    assert first_particle.id == pytest.approx(111.0)  # pi0
+    assert first_particle.status == pytest.approx(0.0)
+    assert first_particle.mother1 == pytest.approx(0.0)
+    assert first_particle.mother2 == pytest.approx(0.0)
+    assert first_particle.px == pytest.approx(-9.7035523745e-01)
+    assert first_particle.py == pytest.approx(-9.8435906372e-01)
+    assert first_particle.pz == pytest.approx(5.1424008917e00)
+    assert first_particle.e == pytest.approx(5.3267140888e00)
+    assert first_particle.m == pytest.approx(1.3800000000e-01)
+
+    # Second particle: 211 (pi+)
+    second_particle = target_event.particles[1]
+    assert second_particle.id == pytest.approx(211.0)  # pi+
+    assert second_particle.status == pytest.approx(0.0)
+    assert second_particle.px == pytest.approx(-2.1024089632e-01)
+    assert second_particle.py == pytest.approx(-3.2883303721e-02)
+    assert second_particle.pz == pytest.approx(3.1406432734e00)
+    assert second_particle.e == pytest.approx(3.1508676134e00)
+    assert second_particle.m == pytest.approx(1.3800000000e-01)
+
+    # Third particle: -211 (pi-)
+    third_particle = target_event.particles[2]
+    assert third_particle.id == pytest.approx(-211.0)  # pi-
+    assert third_particle.status == pytest.approx(0.0)
+    assert third_particle.px == pytest.approx(3.9695103971e-02)
+    assert third_particle.py == pytest.approx(-2.2872518121e-01)
+    assert third_particle.pz == pytest.approx(1.0496526207e-01)
+    assert third_particle.e == pytest.approx(2.8974577830e-01)
+    assert third_particle.m == pytest.approx(1.3800000000e-01)
+
+    # Fourth particle: 2212 (proton)
+    fourth_particle = target_event.particles[3]
+    assert fourth_particle.id == pytest.approx(2212.0)  # proton
+    assert fourth_particle.status == pytest.approx(0.0)
+    assert fourth_particle.px == pytest.approx(-8.6160811751e-01)
+    assert fourth_particle.py == pytest.approx(-7.3819273849e-01)
+    assert fourth_particle.pz == pytest.approx(7.4246467306e00)
+    assert fourth_particle.e == pytest.approx(7.5762050386e00)
+    assert fourth_particle.m == pytest.approx(9.9307937557e-01)
+
+    # Fifth particle: 211 (pi+)
+    fifth_particle = target_event.particles[4]
+    assert fifth_particle.id == pytest.approx(211.0)  # pi+
+    assert fifth_particle.status == pytest.approx(0.0)
+    assert fifth_particle.px == pytest.approx(-4.7889071830e-01)
+    assert fifth_particle.py == pytest.approx(-2.8340027352e-01)
+    assert fifth_particle.pz == pytest.approx(1.5195379346e00)
+    assert fifth_particle.e == pytest.approx(1.6240971553e00)
+    assert fifth_particle.m == pytest.approx(1.3800000000e-01)
+
+    # Test that all particles have proper parent-child relationships
+    for particle in target_event.particles:
+        assert hasattr(particle, "event")
+        assert particle.event is target_event


### PR DESCRIPTION
Test script to monitor memory usage (based on https://github.com/scikit-hep/pylhe/issues/213#issue-1869374586):

```py
import pylhe
import psutil
import os
                                                                                                                                            
afile = "examples/weighted.lhe.gz"
# Get the current process
process = psutil.Process(os.getpid())

# Store memory
prev_rss = None
prev_vms = None

for ievt, evt in enumerate(pylhe.read_lhe(afile)):  # pylhe.read_lhe_with_attributes
    if ievt % 100000 == 0:
        mem_info = process.memory_info()
        rss_mb = mem_info.rss / (1024 * 1024)
        vms_mb = mem_info.vms / (1024 * 1024)

        print(f"\nEvent {ievt}")
        print(f"RSS: {rss_mb:.2f} MB", end='')
        if prev_rss is not None:
            print(f" (Δ {rss_mb - prev_rss:+.2f} MB)")
        else:
            print()

        print(f"VMS: {vms_mb:.2f} MB", end='')
        if prev_vms is not None:
            print(f" (Δ {vms_mb - prev_vms:+.2f} MB)")
        else:
            print()

        # Update previous memory values
        prev_rss = rss_mb
        prev_vms = vms_mb
```

where examples/weighted.lhe.gz is generated by our the Monte Carlo example ipynb with 1M events (any large lhe file works for testing).

Before:
```bash
$ python3.13 test.py

Event 0
RSS: 116.50 MB
VMS: 276.38 MB

Event 100000
RSS: 203.13 MB (Δ +86.62 MB)
VMS: 363.80 MB (Δ +87.42 MB)

Event 200000
RSS: 289.38 MB (Δ +86.25 MB)
VMS: 450.62 MB (Δ +86.82 MB)

Event 300000
RSS: 375.50 MB (Δ +86.12 MB)
VMS: 536.66 MB (Δ +86.04 MB)

Event 400000
RSS: 462.38 MB (Δ +86.88 MB)
VMS: 623.37 MB (Δ +86.71 MB)

Event 500000
RSS: 548.75 MB (Δ +86.38 MB)
VMS: 710.31 MB (Δ +86.95 MB)

Event 600000
RSS: 635.50 MB (Δ +86.75 MB)
VMS: 796.89 MB (Δ +86.58 MB)

Event 700000
RSS: 721.75 MB (Δ +86.25 MB)
VMS: 883.18 MB (Δ +86.29 MB)

Event 800000
RSS: 808.25 MB (Δ +86.50 MB)
VMS: 970.07 MB (Δ +86.89 MB)

Event 900000
RSS: 895.00 MB (Δ +86.75 MB)
VMS: 1056.76 MB (Δ +86.69 MB)
```

After:
```bash
$ python3.13 test.py

Event 0
RSS: 116.29 MB
VMS: 276.37 MB

Event 100000
RSS: 125.79 MB (Δ +9.50 MB)
VMS: 286.36 MB (Δ +9.99 MB)

Event 200000
RSS: 135.29 MB (Δ +9.50 MB)
VMS: 295.16 MB (Δ +8.80 MB)

Event 300000
RSS: 143.79 MB (Δ +8.50 MB)
VMS: 304.12 MB (Δ +8.96 MB)

Event 400000
RSS: 151.79 MB (Δ +8.00 MB)
VMS: 312.80 MB (Δ +8.68 MB)

Event 500000
RSS: 160.16 MB (Δ +8.38 MB)
VMS: 321.66 MB (Δ +8.86 MB)

Event 600000
RSS: 168.79 MB (Δ +8.62 MB)
VMS: 330.17 MB (Δ +8.51 MB)

Event 700000
RSS: 177.41 MB (Δ +8.62 MB)
VMS: 338.39 MB (Δ +8.22 MB)

Event 800000
RSS: 185.79 MB (Δ +8.38 MB)
VMS: 347.12 MB (Δ +8.73 MB)

```

Still growing (not too surprising with python/GC-lang IMO), but a lot better already.

See-also: https://stackoverflow.com/a/28415670

Closes: #213