### PR TITLE
docs: fix sphinx config path for rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,7 +23,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF and ePub
 formats: all


### PR DESCRIPTION
With this fix it builds properly: https://pylhe.readthedocs.io/en/latest/