### PR TITLE
chore: Require graphviz>=0.19 (released late 2021)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 ]
 dependencies = [
     "awkward>=1.2.0",
-    "graphviz>=0.12.0",
+    "graphviz>=0.19",
     "particle>=0.16",
     "vector>=0.8.1",
 ]

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -742,12 +742,7 @@ class LHEEvent(DictCompatibility):
         """
         IPython display helper.
         """
-        try:
-            return self.graph._repr_mimebundle_(
-                include=include, exclude=exclude, **kwargs
-            )
-        except AttributeError:
-            return {"image/svg+xml": self.graph._repr_svg_()}  # for graphviz < 0.19
+        return self.graph._repr_mimebundle_(include=include, exclude=exclude, **kwargs)
 
 
 @dataclass


### PR DESCRIPTION
I think this bump in min version makes sense 4 years down the line.