### PR TITLE
fix: add py.typed marker to wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,6 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pylhe"]
-artifacts = [
-    "src/pylhe/py.typed",
-]
 
 [tool.mypy]
 warn_unused_configs = true


### PR DESCRIPTION
While writing some CLI tools using `pylhe`  https://github.com/APN-Pucky/lheutils running `mypy` currently gives:
```
error: Skipping analyzing "pylhe": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```