### PR TITLE
chore: merge pytest.ini into pyproject and adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,8 @@ addopts = [
     "-ra",
     "--strict-markers",
     "--strict-config",
+    # Non-test dirs that may hold collectable .py/.rst files (e.g. examples/ with future test_* helpers)
+    "--ignore=docs",
     "--cov=pylhe",
     "--cov-report=term-missing",
     "--cov-report=xml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling>=1.13.0",
+    "hatchling>=1.27",
     "hatch-vcs>=0.3.0",
 ]
 build-backend = "hatchling.build"
@@ -10,7 +10,8 @@ name = "pylhe"
 dynamic = ["version"]
 description = "A small package to get structured data out of Les Houches Event files"
 readme = "README.md"
-license = { text = "Apache-2.0" }  # SPDX short identifier
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 authors = [
     { name = "Lukas Heinrich", email = "lukas.heinrich@cern.ch" },
@@ -27,7 +28,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
@@ -124,10 +124,16 @@ minversion = "6.0"
 testpaths = ["tests"]
 log_level = "INFO"
 xfail_strict = true
+junit_family = "xunit2"
 addopts = [
     "-ra",
     "--strict-markers",
     "--strict-config",
+    "--cov=pylhe",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--doctest-modules",
+    "--doctest-glob=*.rst",
 ]
 
 [tool.ruff.lint]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-docstyle_convention = numpy
-junit_family = xunit2
-addopts = --ignore=setup.py --ignore=binder/ --ignore=docs/ --cov=pylhe --cov-report=term-missing --cov-config=.coveragerc --cov-report xml --doctest-modules --doctest-glob='*.rst'


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Part of #378

- **Fix pytest config conflict**: `pytest.ini` was silently overriding `[tool.pytest.ini_options]` in `pyproject.toml` (pytest uses the first config file it finds). This meant `minversion`, `testpaths`, `log_level`, `xfail_strict = true`, `--strict-markers`, `--strict-config`, and `-ra` were all inactive. The fix merges the still-relevant options from `pytest.ini` (`junit_family`, coverage addopts, doctest options) into `[tool.pytest.ini_options]` and deletes `pytest.ini`. Stale ignores (`--ignore=setup.py`, `--ignore=binder/`, `--ignore=docs/`) and the pydocstyle-specific `docstyle_convention = numpy` option are dropped. `--cov-config=.coveragerc` is also removed since that file does not exist.

- **PEP 639 license metadata**: Replaces `license = { text = "Apache-2.0" }` with the SPDX expression form `license = "Apache-2.0"` plus `license-files = ["LICENSE"]`. Removes the `"License :: OSI Approved :: Apache Software License"` classifier (forbidden alongside SPDX license expressions per PEP 639). Bumps `hatchling` build requirement to `>=1.27` (first version with full metadata 2.4 / PEP 639 support). The produced wheel now includes `License-Expression: Apache-2.0` in its METADATA.

## Test plan

- [x] `uv run pytest` passes with `configfile: pyproject.toml` confirmed in the session header
- [x] `--strict-config` and `--strict-markers` are now active (no unknown options or unregistered markers)
- [x] 119 tests pass; 2 failures are pre-existing graphviz binary not installed locally (unrelated)
- [x] `uv build` produces a wheel with `License-Expression: Apache-2.0`
- [x] `prek -a --quiet` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)