### PR TITLE
perf: import awkward/vector/graphviz/particle lazily

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,6 +2,7 @@
 Python interface to read Les Houches Event (LHE) files.
 """
 
+import functools
 import gzip
 import io
 import os
@@ -11,6 +12,7 @@ from collections.abc import Iterable, Iterator
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import (
+    TYPE_CHECKING,
     Any,
     BinaryIO,
     Optional,
@@ -21,12 +23,10 @@ from typing import (
 )
 from xml.sax.saxutils import quoteattr
 
-import graphviz  # type: ignore[import-untyped]
-from particle import latex_to_html_name
-from particle.converters.bimap import DirectionalMaps
-from particle.exceptions import MatchingIDNotFound
-
 from pylhe._version import version as __version__
+
+if TYPE_CHECKING:
+    import graphviz  # type: ignore[import-untyped]
 
 __all__ = [
     "LHEEvent",
@@ -49,8 +49,25 @@ def __dir__() -> list[str]:
     return __all__
 
 
-# retrieve mapping of PDG ID to particle name as LaTeX string
-_PDGID2LaTeXNameMap, _ = DirectionalMaps("PDGID", "LATEXNAME", converters=(str, str))
+def __getattr__(name: str) -> Any:
+    # Lazily expose ``to_awkward`` so that importing ``pylhe`` does not eagerly
+    # import the (heavy) awkward and vector dependencies.
+    if name == "to_awkward":
+        from .awkward import to_awkward  # noqa: PLC0415
+
+        return to_awkward
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+@functools.cache
+def _pdgid_to_latex_name_map() -> Any:
+    # retrieve mapping of PDG ID to particle name as LaTeX string
+    from particle.converters.bimap import DirectionalMaps  # noqa: PLC0415
+
+    pdgid2latex, _ = DirectionalMaps("PDGID", "LATEXNAME", converters=(str, str))
+    return pdgid2latex
+
 
 PathLike = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
 
@@ -694,7 +711,7 @@ class LHEEvent:
     """Event attributes not represented by dedicated fields"""
     optional: list[str] = field(default_factory=list)
     """Optional '#' comments stored in the event"""
-    _graph: Optional[graphviz.Digraph] = None
+    _graph: 'Optional["graphviz.Digraph"]' = None
     """Stores the graph representation of the event generated after first access of the property `lheevent.graph`"""
 
     def __post_init__(self) -> None:
@@ -822,7 +839,7 @@ class LHEEvent:
                 return
 
     @property
-    def graph(self) -> graphviz.Digraph:
+    def graph(self) -> "graphviz.Digraph":
         """
         Get the `graphviz.Digraph` object.
         The user now has full control ...
@@ -841,12 +858,17 @@ class LHEEvent:
         """
         Navigate the particles in the event and produce a Digraph in the DOT language.
         """
+        import graphviz  # noqa: PLC0415
+        from particle import latex_to_html_name  # noqa: PLC0415
+        from particle.exceptions import MatchingIDNotFound  # noqa: PLC0415
+
+        pdgid2latex = _pdgid_to_latex_name_map()
         self._graph = graphviz.Digraph()
         for i, p in enumerate(self.particles):
             iid = int(p.id)
             sid = str(iid)
             try:
-                name = _PDGID2LaTeXNameMap[sid]
+                name = pdgid2latex[sid]
                 texlbl = f"${name}$"
                 label = f'<<table border="0" cellspacing="0" cellborder="0"><tr><td>{latex_to_html_name(name)}</td></tr></table>>'
             except MatchingIDNotFound:
@@ -1133,7 +1155,3 @@ def _open_write_file(filepath: str, gz: bool = False) -> TextIO:
     if filepath.endswith((".gz", ".gzip")) or gz:
         return gzip.open(filepath, "wt")
     return open(filepath, "w")
-
-
-# we import this later to avoid circular imports
-from .awkward import to_awkward  # noqa: E402

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,20 @@
+import subprocess
+import sys
+
 import pylhe
+
+
+def test_lazy_heavy_imports():
+    # Importing pylhe must not eagerly import the heavy optional dependencies.
+    # Run in a fresh interpreter so other tests' imports do not pollute sys.modules.
+    heavy = ("awkward", "vector", "graphviz", "particle")
+    code = (
+        "import sys, pylhe\n"
+        f"heavy = {heavy!r}\n"
+        "loaded = [m for m in heavy if m in sys.modules]\n"
+        "assert not loaded, loaded\n"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
 
 
 def test_top_level_api():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`import pylhe` previously eagerly imported four heavy dependencies that the core reader/writer never needs:

- **awkward** and **vector** — only needed for `to_awkward` (pulled in by the module-bottom `from .awkward import to_awkward`, which also runs `vector.register_awkward()` and several `ak.mixin_class` registrations at import time).
- **graphviz** and **particle** — only needed for the `LHEEvent.graph` visualization (plus the module-level `_PDGID2LaTeXNameMap = DirectionalMaps(...)` construction).

This PR makes all four lazy so the core parse path imports nearly instantly, with **no public API changes**.

## Changes

- Removed the bottom-of-module `from .awkward import to_awkward`; `to_awkward` is now exposed via a module-level `__getattr__` that imports it from `.awkward` on first access (raising the standard `AttributeError` for unknown names). `"to_awkward"` stays in `__all__`/`__dir__`. `from pylhe import to_awkward`, `pylhe.to_awkward`, and `import pylhe.awkward` all still work, and the vector/awkward behavior registrations now happen only when the awkward bridge is actually used.
- Moved the `graphviz`/`particle` imports and the `DirectionalMaps` construction into `LHEEvent._build_graph`. The PDGID→LaTeX map is built once and cached via `functools.cache`. Type annotations are quoted with a `TYPE_CHECKING`-guarded `import graphviz`.
- mypy stays green under `strict` (the `# type: ignore[import-untyped]` for untyped graphviz now lives on the `TYPE_CHECKING` import; no stale ignores).

## Laziness verification

```
python -c "import sys, pylhe; assert not any(m in sys.modules for m in (\"awkward\",\"vector\",\"graphviz\",\"particle\"))"
```

passes after the change. A new `tests/test_api.py::test_lazy_heavy_imports` asserts this in a **fresh interpreter** (via `subprocess.run`) so other tests' imports do not pollute `sys.modules`. `pylhe.to_awkward` and `LHEEvent.graph` were verified end-to-end (covered by `tests/test_awkward.py` and `tests/test_visualize.py`).

## Notes

- Dependencies are intentionally **not** changed: graphviz/particle/awkward/vector remain required deps. Making them optional extras is a possible follow-up, deliberately out of scope here.

Part of #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)