### PR TITLE
feat: LHEH5 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
 
       - uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10',  '3.11', '3.12', '3.13', '3.14']
+        python-version: [3.9', '3.10',  '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9', '3.10',  '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10',  '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: mypy
       files: src
       args: [--show-error-codes]
-      additional_dependencies: [particle, awkward, vector, graphviz]
+      additional_dependencies: [particle, awkward, vector, graphviz, h5py]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Only determined .lhe.gz compression from file extension when no LHEOutputFormat is provided. Otherwise, the compression is determined by the LHEOutputFormat.
 - Weights and weightgroups are now no longer stored in `LHEInit.weightgroup` but in `LHEHeader.initrwgt.entries`. They are thus part of the `<header>` instead of `<init>` as demanded by LHE specification.
 - `LHEInit` no longer has `LHEVersion`. Instead, the version is stored in `LesHoucheEvents.version`.
 - `LHEParticle.mothers()` is now deprecated in favour of `LHEEvent.mothers(particle)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support LHEH5 HDF5 files.
+- Support LHEH5 HDF5 files for reading and writing.
 - CHANGELOG.md file to track updates relevant to library consumers.
 - New dataclass `LHEHeader`.
 - Added `<scales>` to `LHEEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support LHEH5 HDF5 files.
 - CHANGELOG.md file to track updates relevant to library consumers.
 - New dataclass `LHEHeader`.
 - Added `<scales>` to `LHEEvent`.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ file = pylhe.LHEFile(
 )
 
 # write to file, compressed if gz/gzip suffix
-file.tofile("myevents.lhe.gz", lheformat=pylhe.LHEFormat(file=pylhe.LHEFileFormat.GZIP))
+file.tofile("myevents.lhe.gz", lheformat=pylhe.LHEXMLFormat(compress=True))
 ```
 
 

--- a/docs/source/examples/03_write_monte_carlo_example.ipynb
+++ b/docs/source/examples/03_write_monte_carlo_example.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "147dfe17-a5d9-4b68-a07f-6f8d8aa390a1",
    "metadata": {},
    "outputs": [
@@ -95,7 +95,7 @@
     "        * (theta_max - theta_min)\n",
     "        * func(s, theta, phi)\n",
     "        * math.sin(theta)\n",
-    "        for theta, phi in zip(theta_samples, phi_samples)\n",
+    "        for theta, phi in zip(theta_samples, phi_samples, strict=True)\n",
     "    ]\n",
     "    maximum = np.max(func_values)\n",
     "    integral = np.mean(func_values)\n",

--- a/docs/source/examples/20_LHEH5_HDF5.ipynb
+++ b/docs/source/examples/20_LHEH5_HDF5.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "9b1401a1-37ea-4058-a2a4-482a39106fce",
+   "metadata": {},
+   "source": [
+    "# LHEH5/HDF5 example"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "37b55429-a72e-47b2-8bf1-240abd77f259",

--- a/docs/source/examples/20_LHEH5_HDF5.ipynb
+++ b/docs/source/examples/20_LHEH5_HDF5.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "37b55429-a72e-47b2-8bf1-240abd77f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "from tempfile import NamedTemporaryFile\n",
+    "from urllib.request import urlopen\n",
+    "\n",
+    "import hist\n",
+    "\n",
+    "import pylhe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "6785dc2c-a9a1-448e-a42d-33f750118873",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://zenodo.org/records/7751000/files/l2_1.hdf5?download=1\"\n",
+    "with urlopen(url) as response, NamedTemporaryFile(suffix=\".hdf5\") as tmp:\n",
+    "    shutil.copyfileobj(response, tmp)\n",
+    "    tmp.flush()\n",
+    "\n",
+    "    lhe = pylhe.LHEFile.fromfile(tmp.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4bf821bf-e0c1-49cb-a9c0-c7949151da61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr = pylhe.to_awkward(lhe)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "b696fe38-4983-427c-b09f-289e7df8895c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "higgs = arr.particles[(abs(arr.particles.id) == 25) & (arr.particles.status == 1)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "b9f55fb0-84f7-4124-98ce-5d8db074a10c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mass_hist = hist.Hist.new.Reg(30, 0, 50).Int64()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "09760f25-8893-41f1-9540-47452042ab19",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<html>\n",
+       "<div style=\"display:flex; align-items:center;\">\n",
+       "<div style=\"width:290px;\">\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"-10 -105 270 120\">\n",
+       "<line x1=\"-5\" y1=\"0\" x2=\"255\" y2=\"0\" style=\"fill:none;stroke-width:2;stroke:currentColor\"/>\n",
+       "<text text-anchor=\"middle\" x=\"0\" y=\"15\" style=\"fill:currentColor;\">\n",
+       "0\n",
+       "</text>\n",
+       "<text text-anchor=\"middle\" x=\"250\" y=\"15\" style=\"fill:currentColor;\">\n",
+       "50\n",
+       "</text>\n",
+       "<text text-anchor=\"middle\" x=\"125.0\" y=\"15\" style=\"fill:currentColor;\">\n",
+       "Axis 0\n",
+       "</text>\n",
+       "<polyline points=\"  0,0   0,-0.809 8.33333,-0.809 8.33333,-9.36 16.6667,-9.36 16.6667,-14.5  25,-14.5  25,-20.8 33.3333,-20.8 33.3333,-25.7 41.6667,-25.7 41.6667,-36  50,-36  50,-43.8 58.3333,-43.8 58.3333,-38.2 66.6667,-38.2 66.6667,-58  75,-58  75,-59.8 83.3333,-59.8 83.3333,-62.1 91.6667,-62.1 91.6667,-61.6 100,-61.6 100,-59.5 108.333,-59.5 108.333,-61.4 116.667,-61.4 116.667,-70.3 125,-70.3 125,-69.8 133.333,-69.8 133.333,-74 141.667,-74 141.667,-71.3 150,-71.3 150,-80.1 158.333,-80.1 158.333,-79.2 166.667,-79.2 166.667,-78.8 175,-78.8 175,-90.9 183.333,-90.9 183.333,-85.3 191.667,-85.3 191.667,-90.7 200,-90.7 200,-93.5 208.333,-93.5 208.333,-91.9 216.667,-91.9 216.667,-96.5 225,-96.5 225,-87.7 233.333,-87.7 233.333,-100 241.667,-100 241.667,-96.1 250,-96.1 250,0\" style=\"fill:none; stroke:currentColor;\"/>\n",
+       "</svg>\n",
+       "</div>\n",
+       "<div style=\"flex=grow:1;\">\n",
+       "Regular(30, 0, 50, label='Axis 0')<br/>\n",
+       "<hr style=\"margin-top:.2em; margin-bottom:.2em;\"/>\n",
+       "Int64() Σ=7047002756.0 <em>(22394099927.0 with flow)</em>\n",
+       "\n",
+       "</div>\n",
+       "</div>\n",
+       "</html>"
+      ],
+      "text/plain": [
+       "Hist(Regular(30, 0, 50, label='Axis 0'), storage=Int64()) # Sum: 7047002756.0 (22394099927.0 with flow)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# only take first higgs per event\n",
+    "mass_hist.fill(\n",
+    "    higgs.vector[:, 0].pt,\n",
+    "    weight=arr.eventinfo.weight,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "277a5042-afe0-4bf2-8755-6543fabdd8e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAHACAYAAABeV0mSAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAL8tJREFUeJzt3X1clXWe//H3iTshBdMEDysmZpFguga1nqa8CcOwcXVzZ6udMbvzsZRZyTru4DhWbhPdMA6VCvlYkxy37LGDOrmRigVYqTuCsJqma4XhEsTYDRgoIF6/P/x5thNgcDic65yL1/PxuB55Xdf3e/E53xDeXt/rxmYYhiEAAACLuMTsAgAAADyJcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACylT4ebXbt2acaMGYqOjpbNZtOWLVu6fYzt27drwoQJGjBggIYMGaLZs2ersrLS88UCAIAu6dPhprGxUePGjdPKlSvd6v/ZZ59p5syZuuWWW1RRUaHt27fr5MmTuuOOOzxcKQAA6CobL848z2azafPmzZo1a5ZzW0tLi5YuXap///d/17fffqsxY8boueee0+TJkyVJf/zjH3X33XerublZl1xyPidu3bpVM2fOVHNzs4KCgkz4JAAA9G19+szNj7nvvvv04YcfauPGjTpw4IB+9rOf6bbbbtOxY8ckSUlJSQoICNC6devU1tam+vp6/eEPf1BKSgrBBgAAk3Dm5v/74ZmbTz/9VFdddZX+93//V9HR0c52U6dO1Q033KBnnnlG0vnrdn72s5/pq6++UltbmxwOhwoKCjRw4EATPgUAAODMTSf2798vwzB09dVXq3///s6lpKREn376qSSptrZWDz74oObOnat9+/appKREwcHB+vu//3uRGQEAMEeg2QX4qnPnzikgIEBlZWUKCAhw2de/f39J0qpVqxQeHq7nn3/euW/Dhg2KiYnRf/3Xf2nChAlerRkAABBuOjV+/Hi1tbWprq5ON998c4dtmpqa2gWfC+vnzp3r9RoBAEB7fXpa6rvvvlNFRYUqKiokSZWVlaqoqFBVVZWuvvpq/fznP9c999yjTZs2qbKyUvv27dNzzz2ngoICSdLtt9+uffv2afny5Tp27Jj279+v++67T1dccYXGjx9v4icDAKDv6tMXFBcXF2vKlCntts+dO1d5eXlqbW3V008/rfXr16u6ulqDBw+Ww+HQU089pWuvvVaStHHjRj3//PP6n//5H4WFhcnhcOi5557TNddc4+2PAwAA1MfDDQAAsJ4+PS0FAACsh3ADAAAspc/dLXXu3Dl98cUXGjBggGw2m9nlAACALjAMQ6dOnVJ0dLTzlUed6XPh5osvvlBMTIzZZQAAADecOHFCw4YNu2ibPhduBgwYIOn84ISHh5tcDQAA6IqGhgbFxMQ4f49fTJ8LNxemosLDwwk3AAD4ma5cUsIFxQAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFIINwAAwFL63FvBAQCwOsMwdLq1rcfHCQ0K6NJbuH0N4QYAAIs53dqm+GXbe3ycw8unKSzY/6IC01IAAMBS/C+OAQCALitdOlVhwQFdbt/U0qakp3f2YkW9j3ADAICFhQUH+OXUUk8wLQUAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACyFcAMAACylb934DgCAF/X1dzyZhXADAEAv8fd3PDW1uB/MzAxkhBsAANChnryGwcyXbhJuAADwgr74jiezmBpucnJylJOTo+PHj0uSEhIStGzZMqWmpnbYvri4WFOmTGm3/eOPP9Y111zTm6UCANAj/vKOp9CgAB1ePs2tvr4SyEwd5WHDhunZZ5/VqFGjJEmvvfaaZs6cqfLyciUkJHTa7+jRowoPD3euDxkypNdrBQCgL7DZbH4Rwi7G1OpnzJjhsv7b3/5WOTk52rt370XDTWRkpAYOHNjL1QEAAH/kM8+5aWtr08aNG9XY2CiHw3HRtuPHj5fdbldycrKKioou2ra5uVkNDQ0uCwAAsC7Tw83BgwfVv39/hYSEKC0tTZs3b1Z8fHyHbe12u9asWaP8/Hxt2rRJcXFxSk5O1q5duzo9fmZmpiIiIpxLTExMb30UAADgA0yfVIuLi1NFRYW+/fZb5efna+7cuSopKekw4MTFxSkuLs657nA4dOLECWVlZWnixIkdHj8jI0Pp6enO9YaGBgIOAAAWZnq4CQ4Odl5QnJSUpH379unFF1/UK6+80qX+EyZM0IYNGzrdHxISopCQEI/UCgDwTzwpuG8xPdz8kGEYam5u7nL78vJy2e32XqwIAODv/P1JwegeU/8PLVmyRKmpqYqJidGpU6e0ceNGFRcXa9u2bZLOTylVV1dr/fr1kqTs7GyNGDFCCQkJamlp0YYNG5Sfn6/8/HwzPwYAAPAhpoabL7/8UnPmzFFNTY0iIiI0duxYbdu2TbfeeqskqaamRlVVVc72LS0tWrRokaqrqxUaGqqEhAS9/fbbmj59ulkfAQDgZ3hSsPWZGm7Wrl170f15eXku64sXL9bixYt7sSIAgNX5y5OC4T7TbwUHAADwJKIrAABd1NTSvTuuutsenkG4AQCgi7j2xj8wLQUAACyFMzcAAFxEaFCADi+f5pHjwDsINwCAbjHrab89+bo9ufbFZrNxd5Wf4f8WAKBbzHrar6e+LqyPa24AAIClcOYGAOA2s572292v+31c+2J9hBsAgNvMetovTxnGxTAtBQAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIX76AAA8HHdfX1ET143YQWEGwAAfJwnHnzYlzAtBQAALIUzNwAA+KDQoAAdXj7NI8fpawg3AAD4IJvNxism3MS0FAAAsBTCDQAAsBTCDQAAsBQm8wAApuDZLegthBsAgCl4dgt6C9NSAADAUjhzAwDwGp7dAm8g3AAAvIZnt8AbmJYCAACWQrgBAACWQrgBAACWQrgBAACWQrgBAACWQrgBAACWQrgBAACWYmq4ycnJ0dixYxUeHq7w8HA5HA698847F+1TUlKixMRE9evXTyNHjlRubq6XqgUAAP7A1HAzbNgwPfvssyotLVVpaaluueUWzZw5U4cOHeqwfWVlpaZPn66bb75Z5eXlWrJkiR599FHl5+d7uXIAAOCrTH1M5IwZM1zWf/vb3yonJ0d79+5VQkJCu/a5ubkaPny4srOzJUmjR49WaWmpsrKyNHv2bG+UDAAAfJzPXHPT1tamjRs3qrGxUQ6Ho8M2e/bsUUpKisu2adOmqbS0VK2trd4oEwAA+DjTX/Bx8OBBORwOnTlzRv3799fmzZsVHx/fYdva2lpFRUW5bIuKitLZs2d18uRJ2e32dn2am5vV3NzsXG9oaPDsBwAAAD7F9DM3cXFxqqio0N69e/XQQw9p7ty5Onz4cKftbTaby7phGB1uvyAzM1MRERHOJSYmxnPFAwAAn2N6uAkODtaoUaOUlJSkzMxMjRs3Ti+++GKHbYcOHara2lqXbXV1dQoMDNTgwYM77JORkaH6+nrncuLECY9/BgAA4DtMn5b6IcMwXKaRvs/hcGjr1q0u23bs2KGkpCQFBQV12CckJEQhISEerxMAesowDJ1ubfPIsUKDAjo9gw30NaaGmyVLlig1NVUxMTE6deqUNm7cqOLiYm3btk3S+bMu1dXVWr9+vSQpLS1NK1euVHp6uubNm6c9e/Zo7dq1euONN8z8GADgltOtbYpftt0jxzq8fJrCgn3u36uAKUz9m/Dll19qzpw5qqmpUUREhMaOHatt27bp1ltvlSTV1NSoqqrK2T42NlYFBQVauHChVq1apejoaL300kvcBg4AAJxMDTdr16696P68vLx22yZNmqT9+/f3UkUAYI7SpVMVFhzQrT5NLW1Kenqn88/uYkoLVsM5TADwAWHBAT2aVroQctzR3WDVkyAFeAPhBgD6uJ4EI8AXEW4AwE+FBgXo8PJpbvX9/pQWYDWEGwDwUzabze2prJ4Eox8eB/A1hBsA6IN6EowAX2f6E4oBAAA8iXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshXADAAAshbemAejzDMPQ6da2Hh8nNChANpvNAxUB6AnCDYA+73Rrm+KXbe/xcQ4vn8abtgEfwLQUAACwFP6JAQDfU7p0qsKCA7rcvqmlTUlP7+zFigB0F+EGAL4nLDiAqSXAzzEtBQAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVbAgDAQ5pauveU4+62B9A1hBsA8BCedwP4BqalAACApXDmBoDP8McXWIYGBejw8mkeOQ4AzyDcAPAZ/vgCS5vNxhONAR/D30gAlsOFvUDfRrgB4JN68gJLLuwF+jbCDQCfxAssAbiLnxwALIELewFcQLgBYAlc2AvgAlOfc5OZmanrr79eAwYMUGRkpGbNmqWjR49etE9xcbFsNlu75ciRI16qGgAA+DJTw01JSYnmz5+vvXv3qrCwUGfPnlVKSooaGxt/tO/Ro0dVU1PjXK666iovVAwAAHydqedwt23b5rK+bt06RUZGqqysTBMnTrxo38jISA0cOLAXqwMAAP7Ip16/UF9fL0kaNGjQj7YdP3687Ha7kpOTVVRU1Gm75uZmNTQ0uCwAAMC6fCbcGIah9PR03XTTTRozZkyn7ex2u9asWaP8/Hxt2rRJcXFxSk5O1q5duzpsn5mZqYiICOcSExPTWx8BAAD4AJ+5teCRRx7RgQMH9MEHH1y0XVxcnOLi4pzrDodDJ06cUFZWVodTWRkZGUpPT3euNzQ0EHAAALAwnzhzs2DBAr311lsqKirSsGHDut1/woQJOnbsWIf7QkJCFB4e7rIAAADrMvXMjWEYWrBggTZv3qzi4mLFxsa6dZzy8nLZ7XYPVwcAAPyRqeFm/vz5ev311/WnP/1JAwYMUG1trSQpIiJCoaGhks5PK1VXV2v9+vWSpOzsbI0YMUIJCQlqaWnRhg0blJ+fr/z8fNM+BwAA8B2mhpucnBxJ0uTJk122r1u3Tvfee68kqaamRlVVVc59LS0tWrRokaqrqxUaGqqEhAS9/fbbmj59urfKBgAAPsz0aakfk5eX57K+ePFiLV68uJcqAgAA/s4nLigGAADwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFMINAACwFFPfLQXg4gzD0OnWth4fJzQoQDabzQMVAYDvI9wAPux0a5vil23v8XEOL5+msGD+ugPoG/hpB/QBTS3un/3hrA8Af0O4AfxE6dKpCgsO6HL7ppY2JT29U5Kc/3VHd8/69GQqrSchDAAuINwAfiIsOMAvppY8NZUGAO7y/Z+UANwSGhSgw8unudX3+2d9AMDfEG4Ai7LZbKaf6enuVNr3hQa51w8ACDcAeo2/TKUBsBZ+6gC9jAtsAcC7CDdAL/P3C2y7G7AIZADMRrgBcFFcWAzA3xBuAC/iAlsA6H2EG8CL/OUC257cRv7D4wCAt/n+T1kAXucLt5EDgLv46QV0AXc8AYD/INwAXeDvdzwBQF9yidkFAAAAeBJnboBu4o4nAPBtbp25GTlypL766qt227/99luNHDmyx0UBvuzCHU/uLDabzezyAcDy3Ao3x48fV1tb+4skm5ubVV1d3eOiAAAA3NWtaam33nrL+eft27crIiLCud7W1qZ3331XI0aM8FhxAAAA3dWtcDNr1ixJ55+BMXfuXJd9QUFBGjFihH73u995rDgAAIDu6la4OXfunCQpNjZW+/bt0+WXX94rRQEAALjLrbulKisrPV0HAACAR7h9K/i7776rd999V3V1dc4zOhe8+uqrPS4MAADAHW6Fm6eeekrLly9XUlKS7HY7t7cCAACf4Va4yc3NVV5enubMmdOjL56ZmalNmzbpyJEjCg0N1Y033qjnnntOcXFxF+1XUlKi9PR0HTp0SNHR0Vq8eLHS0tJ6VAsAALAGt55z09LSohtvvLHHX7ykpETz58/X3r17VVhYqLNnzyolJUWNjY2d9qmsrNT06dN18803q7y8XEuWLNGjjz6q/Pz8HtcDAAD8n1tnbh588EG9/vrr+s1vftOjL75t2zaX9XXr1ikyMlJlZWWaOHFih31yc3M1fPhwZWdnS5JGjx6t0tJSZWVlafbs2T2qBwAA+D+3ws2ZM2e0Zs0a7dy5U2PHjlVQUJDL/hUrVrhVTH19vSRp0KBBnbbZs2ePUlJSXLZNmzZNa9euVWtra7tampub1dzc7FxvaGhwqzYAAOAf3Ao3Bw4c0F//9V9Lkj766COXfe5eXGwYhtLT03XTTTdpzJgxnbarra1VVFSUy7aoqCidPXtWJ0+elN1ud9mXmZmpp556yq2aAACA/3Er3BQVFXm6Dj3yyCM6cOCAPvjggx9t+8MAZRhGh9slKSMjQ+np6c71hoYGxcTE9LBaAADgq9x+zo0nLViwQG+99ZZ27dqlYcOGXbTt0KFDVVtb67Ktrq5OgYGBGjx4cLv2ISEhCgkJ8Wi9AADAd7kVbqZMmXLR6af33nuvS8cxDEMLFizQ5s2bVVxcrNjY2B/t43A4tHXrVpdtO3bsUFJSUrvrbQAAQN/jVri5cL3NBa2traqoqNBHH33U7oWaFzN//ny9/vrr+tOf/qQBAwY4z8hEREQoNDRU0vlpperqaq1fv16SlJaWppUrVyo9PV3z5s3Tnj17tHbtWr3xxhvufBQAAGAxboWb3//+9x1uf/LJJ/Xdd991+Tg5OTmSpMmTJ7tsX7dune69915JUk1Njaqqqpz7YmNjVVBQoIULF2rVqlWKjo7WSy+9xG3gAABAkoevufnFL36hG264QVlZWV1qf+FC4IvJy8trt23SpEnav39/d8sDAAB9gFtPKO7Mnj171K9fP08eEgAAoFvcOnNzxx13uKwbhqGamhqVlpb2+KnFAAAAPeFWuImIiHBZv+SSSxQXF6fly5e3e3owAACAN7kVbtatW+fpOgAAADyiRxcUl5WV6eOPP5bNZlN8fLzGjx/vqboAAADc4la4qaur01133aXi4mINHDhQhmGovr5eU6ZM0caNGzVkyBBP1wkAANAlbt0ttWDBAjU0NOjQoUP6+uuv9c033+ijjz5SQ0ODHn30UU/XCAAA0GVunbnZtm2bdu7cqdGjRzu3xcfHa9WqVVxQDAAATOXWmZtz5851+B6noKAgnTt3rsdFAQAAuMutcHPLLbfoscce0xdffOHcVl1drYULFyo5OdljxQEAAHSXW+Fm5cqVOnXqlEaMGKErr7xSo0aNUmxsrE6dOqWXX37Z0zUCAAB0mVvX3MTExGj//v0qLCzUkSNHZBiG4uPjNXXqVE/XBwAA0C3dOnPz3nvvKT4+Xg0NDZKkW2+9VQsWLNCjjz6q66+/XgkJCXr//fd7pVAAAICu6Fa4yc7O1rx58xQeHt5uX0REhP7pn/5JK1as8FhxAAAA3dWtcPPf//3fuu222zrdn5KSorKysh4XBQAA4K5uhZsvv/yyw1vALwgMDNRf/vKXHhcFAADgrm6Fm7/6q7/SwYMHO91/4MAB2e32HhcFAADgrm6Fm+nTp2vZsmU6c+ZMu32nT5/WE088oZ/+9KceKw4AAKC7unUr+NKlS7Vp0yZdffXVeuSRRxQXFyebzaaPP/5Yq1atUltbm37961/3Vq0AAAA/qlvhJioqSrt379ZDDz2kjIwMGYYhSbLZbJo2bZpWr16tqKioXikUAACgK7r9EL8rrrhCBQUF+uabb/TJJ5/IMAxdddVVuuyyy3qjPgAAgG5x6wnFknTZZZfp+uuv92QtAAAAPebWu6UAAAB8FeEGAABYCuEGAABYCuEGAABYCuEGAABYitt3SwFmMAxDp1vbenyc0KAA2Ww2D1QEAPA1hBv4ldOtbYpftr3Hxzm8fJrCgvn2BwArYloKAABYCv90hd8qXTpVYcEBXW7f1NKmpKd39mJFAABfQLiB3woLDmBqCQDQDtNSAADAUgg3AADAUgg3AADAUgg3AADAUkwNN7t27dKMGTMUHR0tm82mLVu2XLR9cXGxbDZbu+XIkSPeKRgAAPg8U281aWxs1Lhx43Tfffdp9uzZXe539OhRhYeHO9eHDBnSG+UBAAA/ZGq4SU1NVWpqarf7RUZGauDAgZ4vCAAA+D2/vOZm/PjxstvtSk5OVlFRkdnlAAAAH+JXT0Cz2+1as2aNEhMT1dzcrD/84Q9KTk5WcXGxJk6c2GGf5uZmNTc3O9cbGhq8VS4AADCBX4WbuLg4xcXFOdcdDodOnDihrKysTsNNZmamnnrqKW+VCAAATOaX01LfN2HCBB07dqzT/RkZGaqvr3cuJ06c8GJ1AADA2/zqzE1HysvLZbfbO90fEhKikJAQL1YEAADMZGq4+e677/TJJ5841ysrK1VRUaFBgwZp+PDhysjIUHV1tdavXy9Jys7O1ogRI5SQkKCWlhZt2LBB+fn5ys/PN+sjAAAAH2NquCktLdWUKVOc6+np6ZKkuXPnKi8vTzU1NaqqqnLub2lp0aJFi1RdXa3Q0FAlJCTo7bff1vTp071eOwAA8E2mhpvJkyfLMIxO9+fl5bmsL168WIsXL+7lqgAAgD/z+2tuAHc0tbT1ansAgHkIN+iTkp7eaXYJAIBe4ve3ggMAAHwfZ27QZ4QGBejw8mkeOQ4AwHcRbtBn2Gw2hQXzLQ8AVse0FAAAsBTCDQAAsBTCDQAAsBQuQIDXGYah063uPTeG580AAH4M4QZed7q1TfHLtptdBgDAopiWAgAAlsKZG5iqdOlUhQW799wYnjcDAOgI4QamCgsO4NkzAACPYloKAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYCuEGAABYiqnhZteuXZoxY4aio6Nls9m0ZcuWH+1TUlKixMRE9evXTyNHjlRubm7vFwoAAPyGqeGmsbFR48aN08qVK7vUvrKyUtOnT9fNN9+s8vJyLVmyRI8++qjy8/N7uVIAAOAvAs384qmpqUpNTe1y+9zcXA0fPlzZ2dmSpNGjR6u0tFRZWVmaPXt2L1UJAAD8iV9dc7Nnzx6lpKS4bJs2bZpKS0vV2traYZ/m5mY1NDS4LAAAwLr8KtzU1tYqKirKZVtUVJTOnj2rkydPdtgnMzNTERERziUmJsYbpQIAAJP4VbiRJJvN5rJuGEaH2y/IyMhQfX29czlx4kSv1wgAAMxj6jU33TV06FDV1ta6bKurq1NgYKAGDx7cYZ+QkBCFhIR4ozwAAOAD/CrcOBwObd261WXbjh07lJSUpKCgIJOq6psMw9Dp1ja3+ja1uNcPAICuMDXcfPfdd/rkk0+c65WVlaqoqNCgQYM0fPhwZWRkqLq6WuvXr5ckpaWlaeXKlUpPT9e8efO0Z88erV27Vm+88YZZH6HPOt3apvhl280uAwCAdkwNN6WlpZoyZYpzPT09XZI0d+5c5eXlqaamRlVVVc79sbGxKigo0MKFC7Vq1SpFR0frpZde4jZwAADgZGq4mTx5svOC4I7k5eW12zZp0iTt37+/F6tCd5Uunaqw4AC3+oYGudcPAIDO+NU1N/BNYcEBCgvmWwkA4Bv87lZwAACAiyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAASyHcAAAAS+Fth32YYRg63drmVt+mFvf6AQDQ2wg3fdjp1jbFL9tudhkAAHgU01IAAMBSOHMDSVLp0qkKCw5wq29okHv9AADoDYQbSJLCggMUFsy3AwDA/zEtBQAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALIVwAwAALCXQ7ALQM4Zh6HRrm1t9m1rc6wcAgC8j3Pi5061til+23ewyAADwGaZPS61evVqxsbHq16+fEhMT9f7773fatri4WDabrd1y5MgRL1YMAAB8malnbt588009/vjjWr16tX7yk5/olVdeUWpqqg4fPqzhw4d32u/o0aMKDw93rg8ZMsQb5fq80qVTFRYc4Fbf0CD3+gEA4GtMDTcrVqzQAw88oAcffFCSlJ2dre3btysnJ0eZmZmd9ouMjNTAgQO9VKX/CAsOUFgwM40AgL7NtGmplpYWlZWVKSUlxWV7SkqKdu/efdG+48ePl91uV3JysoqKii7atrm5WQ0NDS4LAACwLtPCzcmTJ9XW1qaoqCiX7VFRUaqtre2wj91u15o1a5Sfn69NmzYpLi5OycnJ2rVrV6dfJzMzUxEREc4lJibGo58DAAD4FtPnMGw2m8u6YRjttl0QFxenuLg457rD4dCJEyeUlZWliRMndtgnIyND6enpzvWGhgYCDgAAFmbamZvLL79cAQEB7c7S1NXVtTubczETJkzQsWPHOt0fEhKi8PBwlwUAAFiXaeEmODhYiYmJKiwsdNleWFioG2+8scvHKS8vl91u93R5AADAT5k6LZWenq45c+YoKSlJDodDa9asUVVVldLS0iSdn1Kqrq7W+vXrJZ2/m2rEiBFKSEhQS0uLNmzYoPz8fOXn55v5MQAAgA8xNdzceeed+uqrr7R8+XLV1NRozJgxKigo0BVXXCFJqqmpUVVVlbN9S0uLFi1apOrqaoWGhiohIUFvv/22pk+fbtZHAAAAPsZmGIZhdhHe1NDQoIiICNXX11vi+pumlrPO1y8cXj6N59wAAEzTm7+TuvP72/TXLwAAAHgS4QYAAFgK4QYAAFgK4QYAAFgK4QYAAFgK4QYAAFgK9w37AMMwdLq1za2+TS3u9QMAwKoINz7gdGub87kAAACgZ5iWAgAAlsKZGx9TunSqwoID3OobGuRePwAArIRw42PCggN4hQIAAD3AtBQAALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAUwg0AALAU08PN6tWrFRsbq379+ikxMVHvv//+RduXlJQoMTFR/fr108iRI5Wbm+ulSi/OMAw1tZx1c2kzu3wAADzCMAw1Hd2tr7/+2rQaAk37ypLefPNNPf7441q9erV+8pOf6JVXXlFqaqoOHz6s4cOHt2tfWVmp6dOna968edqwYYM+/PBDPfzwwxoyZIhmz55twif4P6db2xS/bLupNQAAYLbWk5/rL1ueUfy7L+uxxx7TwoULNWjQIK/WYOqZmxUrVuiBBx7Qgw8+qNGjRys7O1sxMTHKycnpsH1ubq6GDx+u7OxsjR49Wg8++KDuv/9+ZWVleblyAADQEaPtrCQpJSVFK1as0IgRI/Sb3/zGq2dyTDtz09LSorKyMv3qV79y2Z6SkqLdu3d32GfPnj1KSUlx2TZt2jStXbtWra2tCgoK6rV6u6N06VSFBQe41Tc0yL1+AAD4kiVLlmj16tXKysrSihUr9OKLL3rtTI5p4ebkyZNqa2tTVFSUy/aoqCjV1tZ22Ke2trbD9mfPntXJkydlt9vb9WlublZzc7Nzvb6+XpLU0NDQ04/goqnlrM41N0mSzp5p1Nlz7g3tqTOerAoAAO9pajkro/X/fpFFRkbq+eef16JFi1xCTlpamhYsWKCIiIguH/vC723DMH60ranX3EiSzWZzWTcMo922H2vf0fYLMjMz9dRTT7XbHhMT091Su8ye3WuHBgDA71wIOffcc49uueUWvfDCC3rhhRfcOtapU6d+NBSZFm4uv/xyBQQEtDtLU1dX1+7szAVDhw7tsH1gYKAGDx7cYZ+MjAylp6c718+dO6evv/5agwcPvmiIckdDQ4NiYmJ04sQJhYeHe/TY+D+Ms3cwzt7BOHsPY+0dH374oaZPn+6yra6uTi+88IJWr16tgIAA/fKXv+z2mRvDMHTq1ClFR0f/aFvTwk1wcLASExNVWFiov/u7v3NuLyws1MyZMzvs43A4tHXrVpdtO3bsUFJSUqfX24SEhCgkJMRl28CBA3tW/I8IDw/nL44XMM7ewTh7B+PsPYx177r00kudf/5hqElPT+/RNTddDUOmTkulp6drzpw5SkpKksPh0Jo1a1RVVaW0tDRJ58+6VFdXa/369ZKktLQ0rVy5Uunp6Zo3b5727NmjtWvX6o033jDzYwAAgB945pln9M4773gk1HSXqeHmzjvv1FdffaXly5erpqZGY8aMUUFBga644gpJUk1NjaqqqpztY2NjVVBQoIULF2rVqlWKjo7WSy+9ZPozbgAAwHkXZlJ27Njh9VBzgekXFD/88MN6+OGHO9yXl5fXbtukSZO0f//+Xq7KPSEhIXriiSfaTYPBsxhn72CcvYNx9h7G2jvGjx+vf/iHf1B2dnaHdzF7g83oyj1VAAAAfsL0d0sBAAB4EuEGAABYCuEGAABYCuHGQ1avXq3Y2Fj169dPiYmJev/9980uye/t2rVLM2bMUHR0tGw2m7Zs2eKy3zAMPfnkk4qOjlZoaKgmT56sQ4cOmVOsn8rMzNT111+vAQMGKDIyUrNmzdLRo0dd2jDOnpGTk6OxY8c6n7HicDj0zjvvOPczzp6XmZkpm82mxx9/3LmNcfaMJ598UjabzWUZOnSoc7/Z40y48YA333xTjz/+uH7961+rvLxcN998s1JTU11uY0f3NTY2aty4cVq5cmWH+59//nmtWLFCK1eu1L59+zR06FDdeuutOnXqlJcr9V8lJSWaP3++9u7dq8LCQp09e1YpKSlqbGx0tmGcPWPYsGF69tlnVVpaqtLSUt1yyy2aOXOm8wc+4+xZ+/bt05o1azR27FiX7Yyz5yQkJKimpsa5HDx40LnP9HE20GM33HCDkZaW5rLtmmuuMX71q1+ZVJH1SDI2b97sXD937pwxdOhQ49lnn3VuO3PmjBEREWHk5uaaUKE11NXVGZKMkpISwzAY59522WWXGf/2b//GOHvYqVOnjKuuusooLCw0Jk2aZDz22GOGYfD97ElPPPGEMW7cuA73+cI4c+amh1paWlRWVqaUlBSX7SkpKdq9e7dJVVlfZWWlamtrXcY9JCREkyZNYtx7oL6+XpKcD9xinHtHW1ubNm7cqMbGRjkcDsbZw+bPn6/bb79dU6dOddnOOHvWsWPHFB0drdjYWN1111367LPPJPnGOJv+ED9/d/LkSbW1tbV72WdUVFS7l3zCcy6MbUfj/vnnn5tRkt8zDEPp6em66aabNGbMGEmMs6cdPHhQDodDZ86cUf/+/bV582bFx8c7f+Azzj23ceNG7d+/X/v27Wu3j+9nz/mbv/kbrV+/XldffbW+/PJLPf3007rxxht16NAhnxhnwo2H/PAN44ZhePyt42iPcfecRx55RAcOHNAHH3zQbh/j7BlxcXGqqKjQt99+q/z8fM2dO1clJSXO/Yxzz5w4cUKPPfaYduzYoX79+nXajnHuudTUVOefr732WjkcDl155ZV67bXXNGHCBEnmjjPTUj10+eWXKyAgoN1Zmrq6unapFZ5z4ap8xt0zFixYoLfeektFRUUaNmyYczvj7FnBwcEaNWqUkpKSlJmZqXHjxunFF19knD2krKxMdXV1SkxMVGBgoAIDA1VSUqKXXnpJgYGBzrFknD3v0ksv1bXXXqtjx475xPcz4aaHgoODlZiYqMLCQpfthYWFuvHGG02qyvpiY2M1dOhQl3FvaWlRSUkJ494NhmHokUce0aZNm/Tee+8pNjbWZT/j3LsMw1BzczPj7CHJyck6ePCgKioqnEtSUpJ+/vOfq6KiQiNHjmSce0lzc7M+/vhj2e123/h+9splyxa3ceNGIygoyFi7dq1x+PBh4/HHHzcuvfRS4/jx42aX5tdOnTpllJeXG+Xl5YYkY8WKFUZ5ebnx+eefG4ZhGM8++6wRERFhbNq0yTh48KBx9913G3a73WhoaDC5cv/x0EMPGREREUZxcbFRU1PjXJqampxtGGfPyMjIMHbt2mVUVlYaBw4cMJYsWWJccsklxo4dOwzDYJx7y/fvljIMxtlT/vmf/9koLi42PvvsM2Pv3r3GT3/6U2PAgAHO33tmjzPhxkNWrVplXHHFFUZwcLBx3XXXOW+lhfuKiooMSe2WuXPnGoZx/nbDJ554whg6dKgREhJiTJw40Th48KC5RfuZjsZXkrFu3TpnG8bZM+6//37nz4ghQ4YYycnJzmBjGIxzb/lhuGGcPePOO+807Ha7ERQUZERHRxt33HGHcejQIed+s8eZt4IDAABL4ZobAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAH6ruLhYNptNNptNs2bNMrWWESNGOGv59ttvTa0F6OsINwA85t5773X+gg8KCtLIkSO1aNEiNTY2XrTfk08+6ezX2XL8+PFO+x89elR5eXku22pra/XYY49p1KhR6tevn6KionTTTTcpNzdXTU1NXfo8v/vd7xQREdFh+zNnzmjgwIFasWKFJGnfvn3Kz8/v0nEB9C7CDQCPuu2221RTU6PPPvtMTz/9tFavXq1FixZdtM+iRYtUU1PjXIYNG6bly5e7bIuJiem0f2RkpAYOHOhc/+yzzzR+/Hjt2LFDzzzzjMrLy7Vz504tXLhQW7du1c6dO7v0We655x6dPn26w9CSn5+vpqYmzZkzR5I0ZMgQDRo0qEvHBdC7As0uAIC1hISEaOjQoZKkf/zHf1RRUZG2bNminJycTvv0799f/fv3d64HBARowIABzuN018MPP6zAwECVlpbq0ksvdW6/9tprNXv2bH3/lXr19fX65S9/qS1btujMmTNKSkrS73//e40bN05DhgzRjBkz9OqrrzpDzAWvvvqq/vZv/1ZDhgxxq0YAvYczNwB6VWhoqFpbW7329b766ivt2LFD8+fPdwk232ez2SRJhmHo9ttvV21trQoKClRWVqbrrrtOycnJ+vrrryVJDzzwgEpKSlRZWensf/z4cRUVFemBBx7o/Q8EoNsINwB6zZ///Ge9/vrrSk5O9trX/OSTT2QYhuLi4ly2X3755c4zRP/yL/8iSSoqKtLBgwf1H//xH0pKStJVV12lrKwsDRw4UH/84x8lSdOmTVN0dLTLNT3r1q1TdHS0UlJSvPa5AHQd4QaAR/3nf/6n+vfvr379+snhcGjixIl6+eWXvV7HhbMzF/z5z39WRUWFEhIS1NzcLEkqKyvTd999p8GDBzuDT//+/VVZWalPP/1U0vkpsrlz5yovL0/nzp2TYRh67bXXdO+99yogIMDrnwvAj+OaGwAeNWXKFOXk5CgoKEjR0dEKCgry6tcfNWqUbDabjhw54rJ95MiRks5Pk11w7tw52e12FRcXtzvO9y9Qvv/++5WZman33ntPklRVVaX77rvP88UD8AjCDQCPuvTSSzVq1CjTvv7gwYN16623auXKlVqwYEGn191I0nXXXafa2loFBgZqxIgRnba78sorNWnSJK1bt06GYWjy5Mm68sore6F6AJ7AtBQAy1m9erXOnj2rpKQkvfnmm/r444919OhRbdiwQUeOHHFOJ02dOlUOh0OzZs3S9u3bdfz4ce3evVtLly5VaWmpyzEfeOABbdq0SZs3b+ZCYsDHEW4AWM6VV16p8vJyTZ06VRkZGRo3bpySkpL08ssva9GiRfrXf/1XSeevyykoKNDEiRN1//336+qrr9Zdd92l48ePKyoqyuWYs2fPVkhIiEJCQnTHHXeY8bEAdJHN+P4DHwDAjxQXF2vKlCn65ptvXK6RoR6gb+PMDQC/N2zYMN19992m1pCQkKDU1FRTawBwHmduAHhFWlqaNmzY0OG+X/ziF8rNze32MU+fPq3q6mpJ559y7O4TjT3h888/dz6scOTIkbrkEv7tCJiFcAPAK+rq6tTQ0NDhvvDwcEVGRnq5IgBWRbgBAACWwnlTAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKYQbAABgKf8PoHpKMC6+DioAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "artists = mass_hist.plot1d()\n",
+    "ax = artists[0].stairs.axes\n",
+    "# ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"P_T [GeV]\")\n",
+    "ax.set_ylabel(\"Count\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5e15bc8-88e3-463e-a8ed-4b5e2e0eba24",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@
    :caption: Format Reference:
 
    lhe.rst
+   lheh5.rst
    bibliography.rst
 
 .. autosummary::

--- a/docs/source/lheh5.rst
+++ b/docs/source/lheh5.rst
@@ -62,8 +62,8 @@ A typical consolidated LHEH5 file contains the following datasets:
    /procInfo
    /events
    /particles
-   /ctevents      # optional, for MC@NLO S-events
-   /ctparticles   # optional, for MC@NLO S-events
+   /ctevents      # optional, for MC@NLO S-events, not in pylhe
+   /ctparticles   # optional, for MC@NLO S-events, not in pylhe
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/lheh5.rst
+++ b/docs/source/lheh5.rst
@@ -17,7 +17,8 @@ targets.
 
 .. seealso::
 
-   `External LHEH5 format note <https://spice-mc.gitlab.io/pepper/reference/lheh5_format.html>`_.
+   `External LHEH5 format note <https://spice-mc.gitlab.io/pepper/reference/lheh5_format.html>`_
+   part of the Pepper parton-level event generator documentation.
 
 
 Column Labels

--- a/docs/source/lheh5.rst
+++ b/docs/source/lheh5.rst
@@ -1,0 +1,384 @@
+LHEH5 Event Format
+==================
+
+The LHEH5 format is an HDF5-based representation of Les Houches event data
+designed for large parallel workflows.
+It was introduced as an HDF5 analogue of LHEF in :cite:`Hoche:2019flt` and
+refined into a more I/O-efficient layout in :cite:`Bothmann:2023ozs`.
+The goal is to preserve the physics content of ordinary LHE files while
+replacing XML blocks with dense HDF5 datasets that scale better on HPC systems.
+
+The first proposal in :cite:`Hoche:2019flt` mirrored the familiar LHE structure
+with HDF5 groups such as ``init``, ``procInfo``, ``event``, and ``particle``
+and one dataset per quantity.
+The later format definition in :cite:`Bothmann:2023ozs` keeps the same logical
+content but consolidates most quantities into a small number of two-dimensional
+datasets to reduce metadata overhead.
+The consolidated layout is what is usually meant by ``LHEH5`` today and is
+summarized below.
+
+A typical LHEH5 file contains the following datasets:
+
+.. code-block:: text
+
+   /version
+   /init
+   /procInfo
+   /events
+   /particles
+   /ctevents      # optional, only for MC@NLO S-events
+   /ctparticles   # optional, only for MC@NLO S-events
+
+The concrete example file shipped in ``tests/test.hdf5`` is a leading-order
+sample and therefore contains only the core datasets:
+
+.. code-block:: text
+
+   /
+   /events      Dataset {100, 10}
+   /init        Dataset {10}
+   /particles   Dataset {400, 13}
+   /procInfo    Dataset {1, 6}
+   /version     Dataset {3}
+
+The second bundled example, ``tests/j7_1.hdf5``, uses the same logical core
+layout but with extensible event and particle datasets:
+
+.. code-block:: text
+
+   /
+   /events      Dataset {2420/Inf, 10}
+   /init        Dataset {10}
+   /particles   Dataset {24200/Inf, 13}
+   /procInfo    Dataset {1, 6}
+   /version     Dataset {3}
+
+The datasets carry per-column labels as HDF5 attributes.
+In the bundled examples this is usually a ``properties`` attribute, with the
+notable exception that ``tests/j7_1.hdf5`` stores the ``/events`` labels in an
+``events`` attribute.
+The ``events`` dataset contains one row per event, while ``particles`` contains
+one row per particle across all events.
+The pair ``(start, nparticles)`` identifies the slice of ``particles`` that
+belongs to a given event.
+In the optimized layout nearly all values are stored as double precision
+numbers, even when their logical meaning is integer, in order to minimize the
+number of HDF5 objects and improve parallel I/O.
+For the bundled example files, the ``/events`` columns are
+``pid, nparticles, start, trials, scale, fscale, rscale, aqed, aqcd, NOMINAL``;
+the last column stores the nominal event weight.
+``tests/test.hdf5`` stores these labels in a ``properties`` attribute, while
+``tests/j7_1.hdf5`` stores the same labels in an ``events`` attribute.
+
+Below, ``init``, ``procInfo``, ``event(s)``, and ``particle(s)`` refer to the
+logical blocks of the format.
+In the 2019 proposal these were separate HDF5 groups with one dataset per
+quantity, while in the 2024 layout they are packed into consolidated datasets
+named ``init``, ``procInfo``, ``events``, and ``particles``.
+
+The table below summarizes the main published LHEH5 parameters.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 16 10 44 6
+
+   * - Dataset
+     - Parameter
+     - Type
+     - Description
+     - Unit
+   * - ``version``
+     - version
+     - int[3]
+     - Format version triplet
+     - -
+   * - ``init``
+     - beamA
+     - int
+     - PDG ID of first beam particle
+     - -
+   * - ``init``
+     - beamB
+     - int
+     - PDG ID of second beam particle
+     - -
+   * - ``init``
+     - energyA
+     - float
+     - Energy of first beam particle
+     - GeV
+   * - ``init``
+     - energyB
+     - float
+     - Energy of second beam particle
+     - GeV
+   * - ``init``
+     - PDFgroupA
+     - int
+     - PDF group ID for first beam
+     - -
+   * - ``init``
+     - PDFgroupB
+     - int
+     - PDF group ID for second beam
+     - -
+   * - ``init``
+     - PDFsetA
+     - int
+     - PDF set ID for first beam
+     - -
+   * - ``init``
+     - PDFsetB
+     - int
+     - PDF set ID for second beam
+     - -
+   * - ``init``
+     - weightingStrategy
+     - int
+     - Event-weighting strategy
+     - -
+   * - ``init``
+     - numProcesses
+     - int
+     - Number of subprocesses stored in the file
+     - -
+   * - ``procInfo``
+     - procId
+     - int
+     - Process ID
+     - -
+   * - ``procInfo``
+     - xSection
+     - float
+     - Cross section
+     - pb
+   * - ``procInfo``
+     - error
+     - float
+     - Cross section uncertainty
+     - pb
+   * - ``procInfo``
+     - unitWeight
+     - float
+     - Unit weight / maximum weight for unweighting
+     - pb
+   * - ``procInfo``
+     - npLO
+     - int
+     - LO final-state multiplicity tag
+     - -
+   * - ``procInfo``
+     - npNLO
+     - int
+     - Born-level multiplicity tag for NLO samples
+     - -
+   * - ``event(s)``
+     - nparticles
+     - int
+     - Number of particles in the event
+     - -
+   * - ``event(s)``
+     - start
+     - int
+     - Offset of the first particle record
+     - -
+   * - ``event(s)``
+     - pid
+     - int
+     - Process ID for this event
+     - -
+   * - ``event(s)``
+     - weight / ``NOMINAL``
+     - float
+     - Nominal event weight; the example file names this column ``NOMINAL``
+     - -
+   * - ``event(s)``
+     - scale
+     - float
+     - Nominal event scale
+     - GeV
+   * - ``event(s)``
+     - fscale
+     - float
+     - Factorization scale
+     - GeV
+   * - ``event(s)``
+     - rscale
+     - float
+     - Renormalization scale
+     - GeV
+   * - ``event(s)``
+     - aqed
+     - float
+     - QED coupling constant
+     - -
+   * - ``event(s)``
+     - aqcd
+     - float
+     - QCD coupling constant
+     - -
+   * - ``event(s)``
+     - npLO
+     - int
+     - LO multiplicity tag for this event
+     - -
+   * - ``event(s)``
+     - npNLO
+     - int
+     - NLO/Born multiplicity tag for this event
+     - -
+   * - ``event(s)``
+     - trials
+     - float
+     - Number of trials used during unweighting
+     - -
+   * - ``particle(s)``
+     - id
+     - int
+     - PDG particle ID
+     - -
+   * - ``particle(s)``
+     - status
+     - int
+     - Particle status code
+     - -
+   * - ``particle(s)``
+     - mother1
+     - int
+     - Index of first mother particle
+     - -
+   * - ``particle(s)``
+     - mother2
+     - int
+     - Index of second mother particle
+     - -
+   * - ``particle(s)``
+     - color1
+     - int
+     - First color line index
+     - -
+   * - ``particle(s)``
+     - color2
+     - int
+     - Second color line index
+     - -
+   * - ``particle(s)``
+     - px
+     - float
+     - x-component of momentum
+     - GeV
+   * - ``particle(s)``
+     - py
+     - float
+     - y-component of momentum
+     - GeV
+   * - ``particle(s)``
+     - pz
+     - float
+     - z-component of momentum
+     - GeV
+   * - ``particle(s)``
+     - e
+     - float
+     - Energy
+     - GeV
+   * - ``particle(s)``
+     - m
+     - float
+     - Mass
+     - GeV
+   * - ``particle(s)``
+     - lifetime
+     - float
+     - Proper lifetime
+     - mm
+   * - ``particle(s)``
+     - spin
+     - float
+     - Spin information
+     - -
+   * - ``ctevents``
+     - ijt
+     - int
+     - Born-level dipole index for the counterterm
+     - -
+   * - ``ctevents``
+     - kt
+     - int
+     - Counterterm kinematics or dipole label
+     - -
+   * - ``ctevents``
+     - i
+     - int
+     - Real-emission particle index ``i``
+     - -
+   * - ``ctevents``
+     - j
+     - int
+     - Real-emission particle index ``j``
+     - -
+   * - ``ctevents``
+     - k
+     - int
+     - Spectator particle index ``k``
+     - -
+   * - ``ctevents``
+     - z1
+     - float
+     - First KP integration variable
+     - -
+   * - ``ctevents``
+     - z2
+     - float
+     - Second KP integration variable
+     - -
+   * - ``ctevents``
+     - bbpsw
+     - float
+     - Single-emission phase-space weight
+     - -
+   * - ``ctevents``
+     - tlpsw
+     - float
+     - Born phase-space weight
+     - -
+   * - ``ctparticles``
+     - px
+     - float
+     - x-component of counterterm momentum
+     - GeV
+   * - ``ctparticles``
+     - py
+     - float
+     - y-component of counterterm momentum
+     - GeV
+   * - ``ctparticles``
+     - pz
+     - float
+     - z-component of counterterm momentum
+     - GeV
+   * - ``ctparticles``
+     - e
+     - float
+     - Energy of counterterm momentum
+     - GeV
+
+For concrete files the column-label attribute should always be treated as
+authoritative for the exact on-disk column order and field naming.
+In the examples bundled with this repository that means consulting
+``properties`` for most datasets, but also allowing for the event-column labels
+to appear under ``events`` as in ``tests/j7_1.hdf5``.
+This matters because the 2019 and 2024 papers describe the same logical event
+content with different levels of packing and optimization, and the bundled
+example files store the event weight under the property name ``NOMINAL``.
+
+Compared to XML-based LHE files, LHEH5 is less flexible for arbitrary metadata
+but better suited to high-throughput parallel I/O.
+The 2024 paper also adds the explicit ``version`` dataset and the optional
+``ctevents`` and ``ctparticles`` datasets needed for MC@NLO ``S``-events,
+while ordinary leading-order and hard-remainder events can be described by the
+core ``init``, ``procInfo``, ``events``, and ``particles`` content alone.
+
+``pylhe`` does not currently implement LHEH5 parsing or writing, but the
+summary above documents the published format proposals and their relationship
+to the ordinary LHE structure.

--- a/docs/source/lheh5.rst
+++ b/docs/source/lheh5.rst
@@ -379,6 +379,6 @@ The 2024 paper also adds the explicit ``version`` dataset and the optional
 while ordinary leading-order and hard-remainder events can be described by the
 core ``init``, ``procInfo``, ``events``, and ``particles`` content alone.
 
-``pylhe`` does not currently implement LHEH5 parsing or writing, but the
-summary above documents the published format proposals and their relationship
-to the ordinary LHE structure.
+``pylhe`` implements reading and writing of the core consolidated LHEH5 datasets
+(``/version``, ``/init``, ``/procInfo``, ``/events``, ``/particles``) via
+:py:meth:`pylhe.LesHouchesEvents.fromfile` and :py:meth:`pylhe.LesHouchesEvents.tofile`.

--- a/docs/source/lheh5.rst
+++ b/docs/source/lheh5.rst
@@ -1,23 +1,59 @@
 LHEH5 Event Format
 ==================
 
-The LHEH5 format is an HDF5-based representation of Les Houches event data
-designed for large parallel workflows.
-It was introduced as an HDF5 analogue of LHEF in :cite:`Hoche:2019flt` and
-refined into a more I/O-efficient layout in :cite:`Bothmann:2023ozs`.
-The goal is to preserve the physics content of ordinary LHE files while
-replacing XML blocks with dense HDF5 datasets that scale better on HPC systems.
+LHEH5 is an HDF5-based representation of Les Houches Event data.
+It preserves the same core physics information as XML-based LHEF while storing
+it in dense datasets that are better suited to high-throughput and parallel I/O.
+The format was introduced as an HDF5 analogue of LHEF in
+:cite:`Hoche:2019flt` and later consolidated into a compact dataset-oriented
+layout in :cite:`Bothmann:2023ozs`.
 
-The first proposal in :cite:`Hoche:2019flt` mirrored the familiar LHE structure
-with HDF5 groups such as ``init``, ``procInfo``, ``event``, and ``particle``
-and one dataset per quantity.
-The later format definition in :cite:`Bothmann:2023ozs` keeps the same logical
-content but consolidates most quantities into a small number of two-dimensional
-datasets to reduce metadata overhead.
-The consolidated layout is what is usually meant by ``LHEH5`` today and is
-summarized below.
+In practice, most LHEH5 files encountered today use a small set of top-level
+datasets for run information, per-process metadata, per-event data, and
+per-particle data.
+Additional datasets and columns may be present for tool-specific extensions,
+but the core layout summarized here is the interoperable part that ``pylhe``
+targets.
 
-A typical LHEH5 file contains the following datasets:
+.. seealso::
+
+   `External LHEH5 format note <https://spice-mc.gitlab.io/pepper/reference/lheh5_format.html>`_.
+
+
+Column Labels
+-------------
+
+The authoritative mapping between on-disk columns and physical quantities is
+stored in HDF5 dataset attributes.
+Most files use a ``properties`` attribute.
+Some older files instead store the same labels in an attribute named after the
+dataset itself, for example ``events`` on the ``/events`` dataset.
+Robust readers should consult these attributes instead of assuming a fixed
+column order.
+
+The ``events`` dataset contains one row per event, while ``particles``
+contains one row per particle across the whole file.
+The pair ``(start, nparticles)`` identifies the slice of ``particles`` that
+belongs to a given event.
+Many producers store nearly all numeric values as double precision numbers,
+even when their logical meaning is integer, to keep the layout uniform.
+
+
+Version Dataset
+---------------
+
+The ``/version`` dataset stores a three-integer triplet
+``[major, minor, patch]``.
+It identifies the on-disk layout written by the producer, but version numbers
+should not replace attribute-based column discovery.
+Writers may normalize output to the latest version they support, while readers
+should continue to interpret columns by name.
+
+
+Dataset Summary
+---------------
+
+A typical consolidated LHEH5 file contains the following datasets:
 
 .. code-block:: text
 
@@ -26,358 +62,369 @@ A typical LHEH5 file contains the following datasets:
    /procInfo
    /events
    /particles
-   /ctevents      # optional, only for MC@NLO S-events
-   /ctparticles   # optional, only for MC@NLO S-events
-
-The concrete example file shipped in ``tests/test.hdf5`` is a leading-order
-sample and therefore contains only the core datasets:
-
-.. code-block:: text
-
-   /
-   /events      Dataset {100, 10}
-   /init        Dataset {10}
-   /particles   Dataset {400, 13}
-   /procInfo    Dataset {1, 6}
-   /version     Dataset {3}
-
-The second bundled example, ``tests/j7_1.hdf5``, uses the same logical core
-layout but with extensible event and particle datasets:
-
-.. code-block:: text
-
-   /
-   /events      Dataset {2420/Inf, 10}
-   /init        Dataset {10}
-   /particles   Dataset {24200/Inf, 13}
-   /procInfo    Dataset {1, 6}
-   /version     Dataset {3}
-
-The datasets carry per-column labels as HDF5 attributes.
-In the bundled examples this is usually a ``properties`` attribute, with the
-notable exception that ``tests/j7_1.hdf5`` stores the ``/events`` labels in an
-``events`` attribute.
-The ``events`` dataset contains one row per event, while ``particles`` contains
-one row per particle across all events.
-The pair ``(start, nparticles)`` identifies the slice of ``particles`` that
-belongs to a given event.
-In the optimized layout nearly all values are stored as double precision
-numbers, even when their logical meaning is integer, in order to minimize the
-number of HDF5 objects and improve parallel I/O.
-For the bundled example files, the ``/events`` columns are
-``pid, nparticles, start, trials, scale, fscale, rscale, aqed, aqcd, NOMINAL``;
-the last column stores the nominal event weight.
-``tests/test.hdf5`` stores these labels in a ``properties`` attribute, while
-``tests/j7_1.hdf5`` stores the same labels in an ``events`` attribute.
-
-Below, ``init``, ``procInfo``, ``event(s)``, and ``particle(s)`` refer to the
-logical blocks of the format.
-In the 2019 proposal these were separate HDF5 groups with one dataset per
-quantity, while in the 2024 layout they are packed into consolidated datasets
-named ``init``, ``procInfo``, ``events``, and ``particles``.
-
-The table below summarizes the main published LHEH5 parameters.
+   /ctevents      # optional, for MC@NLO S-events
+   /ctparticles   # optional, for MC@NLO S-events
 
 .. list-table::
    :header-rows: 1
-   :widths: 16 16 10 44 6
+   :widths: 18 16 10 56
 
    * - Dataset
-     - Parameter
+     - Typical shape
+     - Type
+     - Purpose
+   * - ``version``
+     - ``(3,)``
+     - int
+     - Format version triplet ``[major, minor, patch]``
+   * - ``init``
+     - ``(10,)``
+     - usually float64
+     - Global run properties, analogous to the LHEF ``<init>`` block
+   * - ``procInfo``
+     - ``(P, 6+)``
+     - usually float64
+     - Per-process metadata
+   * - ``events``
+     - ``(N, 10+)``
+     - usually float64
+     - Per-event record, including the particle slice locator
+   * - ``particles``
+     - ``(K, 13)``
+     - usually float64
+     - Per-particle record across all events
+   * - ``ctevents``
+     - ``(N_ct, 9)``
+     - usually float64
+     - Counterterm metadata for MC@NLO ``S``-events
+   * - ``ctparticles``
+     - ``(K_ct, 4)``
+     - usually float64
+     - Counterterm four-momenta for MC@NLO ``S``-events
+
+Here ``P`` is the number of subprocess entries, ``N`` is the number of events,
+and ``K`` is the total number of particle rows.
+The ``+`` sign indicates that additional implementation-defined columns may be
+appended beyond the common core columns described below.
+
+
+``init``
+--------
+
+``init`` is a one-dimensional dataset containing global run information.
+Its common columns are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
      - Type
      - Description
      - Unit
-   * - ``version``
-     - version
-     - int[3]
-     - Format version triplet
-     - -
-   * - ``init``
-     - beamA
+   * - ``beamA``
      - int
-     - PDG ID of first beam particle
+     - PDG ID of the first beam particle
      - -
-   * - ``init``
-     - beamB
+   * - ``beamB``
      - int
-     - PDG ID of second beam particle
+     - PDG ID of the second beam particle
      - -
-   * - ``init``
-     - energyA
+   * - ``energyA``
      - float
-     - Energy of first beam particle
+     - Energy of the first beam particle
      - GeV
-   * - ``init``
-     - energyB
+   * - ``energyB``
      - float
-     - Energy of second beam particle
+     - Energy of the second beam particle
      - GeV
-   * - ``init``
-     - PDFgroupA
+   * - ``PDFgroupA``
      - int
-     - PDF group ID for first beam
+     - PDF group ID for the first beam
      - -
-   * - ``init``
-     - PDFgroupB
+   * - ``PDFgroupB``
      - int
-     - PDF group ID for second beam
+     - PDF group ID for the second beam
      - -
-   * - ``init``
-     - PDFsetA
+   * - ``PDFsetA``
      - int
-     - PDF set ID for first beam
+     - PDF set ID for the first beam
      - -
-   * - ``init``
-     - PDFsetB
+   * - ``PDFsetB``
      - int
-     - PDF set ID for second beam
+     - PDF set ID for the second beam
      - -
-   * - ``init``
-     - weightingStrategy
+   * - ``weightingStrategy``
      - int
      - Event-weighting strategy
      - -
-   * - ``init``
-     - numProcesses
+   * - ``numProcesses``
      - int
-     - Number of subprocesses stored in the file
+     - Number of subprocess rows stored in ``procInfo``
      - -
-   * - ``procInfo``
-     - procId
+
+
+``procInfo``
+------------
+
+``procInfo`` is a two-dimensional dataset with one row per subprocess.
+Its common core columns are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
+     - Type
+     - Description
+     - Unit
+   * - ``procId``
      - int
-     - Process ID
+     - Process identifier
      - -
-   * - ``procInfo``
-     - xSection
-     - float
-     - Cross section
-     - pb
-   * - ``procInfo``
-     - error
-     - float
-     - Cross section uncertainty
-     - pb
-   * - ``procInfo``
-     - unitWeight
-     - float
-     - Unit weight / maximum weight for unweighting
-     - pb
-   * - ``procInfo``
-     - npLO
+   * - ``npLO``
      - int
      - LO final-state multiplicity tag
      - -
-   * - ``procInfo``
-     - npNLO
+   * - ``npNLO``
      - int
-     - Born-level multiplicity tag for NLO samples
+     - NLO or Born-level multiplicity tag
      - -
-   * - ``event(s)``
-     - nparticles
-     - int
-     - Number of particles in the event
-     - -
-   * - ``event(s)``
-     - start
-     - int
-     - Offset of the first particle record
-     - -
-   * - ``event(s)``
-     - pid
+   * - ``xSection``
+     - float
+     - Cross section for this process
+     - pb
+   * - ``error``
+     - float
+     - Cross section uncertainty
+     - pb
+   * - ``unitWeight``
+     - float
+     - Unit weight or maximum weight used for unweighting
+     - pb
+
+Some producers append further process-level metadata.
+As with all LHEH5 datasets, the attribute labels should be treated as
+authoritative for the exact on-disk layout.
+
+
+``events``
+----------
+
+``events`` is a two-dimensional dataset with one row per event.
+The most common event-level columns are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
+     - Type
+     - Description
+     - Unit
+   * - ``pid``
      - int
      - Process ID for this event
      - -
-   * - ``event(s)``
-     - weight / ``NOMINAL``
-     - float
-     - Nominal event weight; the example file names this column ``NOMINAL``
-     - -
-   * - ``event(s)``
-     - scale
-     - float
-     - Nominal event scale
-     - GeV
-   * - ``event(s)``
-     - fscale
-     - float
-     - Factorization scale
-     - GeV
-   * - ``event(s)``
-     - rscale
-     - float
-     - Renormalization scale
-     - GeV
-   * - ``event(s)``
-     - aqed
-     - float
-     - QED coupling constant
-     - -
-   * - ``event(s)``
-     - aqcd
-     - float
-     - QCD coupling constant
-     - -
-   * - ``event(s)``
-     - npLO
+   * - ``nparticles``
      - int
-     - LO multiplicity tag for this event
+     - Number of particles belonging to this event
      - -
-   * - ``event(s)``
-     - npNLO
+   * - ``start``
      - int
-     - NLO/Born multiplicity tag for this event
+     - Offset of the first particle row for this event in ``particles``
      - -
-   * - ``event(s)``
-     - trials
+   * - ``trials``
      - float
      - Number of trials used during unweighting
      - -
-   * - ``particle(s)``
-     - id
+   * - ``scale``
+     - float
+     - Nominal hard-process scale
+     - GeV
+   * - ``fscale``
+     - float
+     - Factorization scale
+     - GeV
+   * - ``rscale``
+     - float
+     - Renormalization scale
+     - GeV
+   * - ``aqed``
+     - float
+     - QED coupling constant
+     - -
+   * - ``aqcd``
+     - float
+     - QCD coupling constant
+     - -
+   * - ``weight`` or ``NOMINAL``
+     - float
+     - Nominal event weight
+     - pb
+
+Some files append further event-level columns, for example multiplicity tags or
+auxiliary weights.
+Readers should discover such columns from the dataset attributes rather than
+assuming a fixed width.
+
+
+``particles``
+-------------
+
+``particles`` is a two-dimensional dataset with one row per particle.
+Its standard columns mirror the ordinary LHE particle record:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
+     - Type
+     - Description
+     - Unit
+   * - ``id``
      - int
      - PDG particle ID
      - -
-   * - ``particle(s)``
-     - status
+   * - ``status``
      - int
      - Particle status code
      - -
-   * - ``particle(s)``
-     - mother1
+   * - ``mother1``
      - int
-     - Index of first mother particle
+     - Index of the first mother particle
      - -
-   * - ``particle(s)``
-     - mother2
+   * - ``mother2``
      - int
-     - Index of second mother particle
+     - Index of the second mother particle
      - -
-   * - ``particle(s)``
-     - color1
+   * - ``color1``
      - int
-     - First color line index
+     - First color-line index
      - -
-   * - ``particle(s)``
-     - color2
+   * - ``color2``
      - int
-     - Second color line index
+     - Second color-line index
      - -
-   * - ``particle(s)``
-     - px
+   * - ``px``
      - float
      - x-component of momentum
      - GeV
-   * - ``particle(s)``
-     - py
+   * - ``py``
      - float
      - y-component of momentum
      - GeV
-   * - ``particle(s)``
-     - pz
+   * - ``pz``
      - float
      - z-component of momentum
      - GeV
-   * - ``particle(s)``
-     - e
+   * - ``e``
      - float
      - Energy
      - GeV
-   * - ``particle(s)``
-     - m
+   * - ``m``
      - float
      - Mass
      - GeV
-   * - ``particle(s)``
-     - lifetime
+   * - ``lifetime``
      - float
      - Proper lifetime
      - mm
-   * - ``particle(s)``
-     - spin
+   * - ``spin``
      - float
      - Spin information
      - -
-   * - ``ctevents``
-     - ijt
+
+.. note::
+
+   ``mother1`` and ``mother2`` use the usual LHE convention: indices are
+   1-based within the event, and ``0`` denotes an absent mother.
+
+
+``ctevents`` and ``ctparticles``
+--------------------------------
+
+These optional datasets are used for MC@NLO ``S``-events in the extended
+LHEH5 layout described in :cite:`Bothmann:2023ozs`.
+
+``ctevents`` stores one counterterm row per record:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
+     - Type
+     - Description
+     - Unit
+   * - ``ijt``
      - int
-     - Born-level dipole index for the counterterm
+     - Born-level dipole index used for the counterterm
      - -
-   * - ``ctevents``
-     - kt
+   * - ``kt``
      - int
      - Counterterm kinematics or dipole label
      - -
-   * - ``ctevents``
-     - i
+   * - ``i``
      - int
      - Real-emission particle index ``i``
      - -
-   * - ``ctevents``
-     - j
+   * - ``j``
      - int
      - Real-emission particle index ``j``
      - -
-   * - ``ctevents``
-     - k
+   * - ``k``
      - int
      - Spectator particle index ``k``
      - -
-   * - ``ctevents``
-     - z1
+   * - ``z1``
      - float
      - First KP integration variable
      - -
-   * - ``ctevents``
-     - z2
+   * - ``z2``
      - float
      - Second KP integration variable
      - -
-   * - ``ctevents``
-     - bbpsw
+   * - ``bbpsw``
+     - float
+     - Born-level phase-space weight
+     - -
+   * - ``tlpsw``
      - float
      - Single-emission phase-space weight
      - -
-   * - ``ctevents``
-     - tlpsw
-     - float
-     - Born phase-space weight
-     - -
-   * - ``ctparticles``
-     - px
+
+``ctparticles`` stores the corresponding counterterm four-momenta:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 10 52 8
+
+   * - Column
+     - Type
+     - Description
+     - Unit
+   * - ``px``
      - float
      - x-component of counterterm momentum
      - GeV
-   * - ``ctparticles``
-     - py
+   * - ``py``
      - float
      - y-component of counterterm momentum
      - GeV
-   * - ``ctparticles``
-     - pz
+   * - ``pz``
      - float
      - z-component of counterterm momentum
      - GeV
-   * - ``ctparticles``
-     - e
+   * - ``e``
      - float
      - Energy of counterterm momentum
      - GeV
 
-For concrete files the column-label attribute should always be treated as
-authoritative for the exact on-disk column order and field naming.
-In the examples bundled with this repository that means consulting
-``properties`` for most datasets, but also allowing for the event-column labels
-to appear under ``events`` as in ``tests/j7_1.hdf5``.
-This matters because the 2019 and 2024 papers describe the same logical event
-content with different levels of packing and optimization, and the bundled
-example files store the event weight under the property name ``NOMINAL``.
 
-Compared to XML-based LHE files, LHEH5 is less flexible for arbitrary metadata
-but better suited to high-throughput parallel I/O.
-The 2024 paper also adds the explicit ``version`` dataset and the optional
-``ctevents`` and ``ctparticles`` datasets needed for MC@NLO ``S``-events,
-while ordinary leading-order and hard-remainder events can be described by the
-core ``init``, ``procInfo``, ``events``, and ``particles`` content alone.
+Support in ``pylhe``
+--------------------
 
 ``pylhe`` implements reading and writing of the core consolidated LHEH5 datasets
 (``/version``, ``/init``, ``/procInfo``, ``/events``, ``/particles``) via

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -33,3 +33,33 @@
     month = "3",
     year = "2010"
 }
+
+@article{Bothmann:2023ozs,
+    author = {Bothmann, Enrico and Childers, Taylor and G{\"u}tschow, Christian and H{\"o}che, Stefan and Hovland, Paul and Isaacson, Joshua and Knobbe, Max and Latham, Robert},
+    title = "{Efficient precision simulation of processes with many-jet final states at the LHC}",
+    eprint = "2309.13154",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-23-439-T, MCNET-23-14, MCNET-23-10",
+    doi = "10.1103/PhysRevD.109.014013",
+    journal = "Phys. Rev. D",
+    volume = "109",
+    number = "1",
+    pages = "014013",
+    year = "2024"
+}
+
+@article{Hoche:2019flt,
+    author = {H{\"o}che, Stefan and Prestel, Stefan and Schulz, Holger},
+    title = "{Simulation of Vector Boson Plus Many Jet Final States at the High Luminosity LHC}",
+    eprint = "1905.05120",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-19-192-T, LU-TP 19-14, MCNET-19-09",
+    doi = "10.1103/PhysRevD.100.014024",
+    journal = "Phys. Rev. D",
+    volume = "100",
+    number = "1",
+    pages = "014024",
+    year = "2019"
+}

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ dependencies:
   - hist>=2
   # needed by parquet cache
   - pyarrow
-  - scikit-hep-testdata>=0.5.5
+  - scikit-hep-testdata>=0.6.6
   - pip:
     - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "graphviz>=0.19",
     "particle>=0.25",
     "vector>=1.5.2",
-    "h5py",
+    "h5py>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "graphviz>=0.19",
     "particle>=0.25",
     "vector>=1.5.2",
+    "h5py",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "pytest>=7.0",
     "pytest-benchmark",
     "pytest-cov>=6.0",
-    "scikit-hep-testdata>=0.5.5",
+    "scikit-hep-testdata>=0.6.6",
 ]
 develop = [
     "pylhe[lint,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "A small package to get structured data out of Les Houches Event f
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Lukas Heinrich", email = "lukas.heinrich@cern.ch" },
     { name = "Matthew Feickert", email = "matthew.feickert@cern.ch" },
@@ -30,7 +30,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -110,7 +109,7 @@ packages = ["src/pylhe"]
 [tool.mypy]
 warn_unused_configs = true
 warn_unused_ignores = true
-python_version = "3.9"
+python_version = "3.10"
 files = "src"
 strict = true
 warn_unreachable = true

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -185,7 +185,7 @@ class LHEEventInfo:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the event info as a string in LHE format.
+        Return the event info as a string in LHE XML format.
 
         Returns:
             str: The event info as a string in LHE format.
@@ -440,13 +440,13 @@ class LHEProcInfo:
         """
         if self.npLO is not None:
             warnings.warn(
-                "LHEH5 field npLO has not equivalent in LHE format and will be ignored.",
+                "LHEH5 field npLO has no equivalent in the LHE XML format and will be ignored.",
                 UserWarning,
                 stacklevel=2,
             )
         if self.npNLO is not None:
             warnings.warn(
-                "LHEH5 field npNLO has not equivalent in LHE format and will be ignored.",
+                "LHEH5 field npNLO has no equivalent in the LHE XML format and will be ignored.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -822,7 +822,7 @@ class LHEEvent:
         Return the event as a string in LHE format.
 
         Args:
-            format (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat Enum`.
+            format (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat` class.
 
         Returns:
             str: The event as a string in LHE format.
@@ -1084,7 +1084,7 @@ class LesHouchesEvents:
 
         Args:
             filepath (PathLike): Path to the output file.
-            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat`.
+            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat` class.
         """
         # autodetect default format from suffix if not provided
         if lheformat is None:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -2,6 +2,8 @@
 Python interface to read Les Houches Event (LHE) files.
 """
 
+from __future__ import annotations
+
 import enum
 import gzip
 import io
@@ -189,7 +191,7 @@ class LHEEventInfo:
         )
 
     @classmethod
-    def fromstring(cls, string: str) -> "LHEEventInfo":
+    def fromstring(cls, string: str) -> LHEEventInfo:
         """
         Create an `LHEEventInfo` instance from a string in LHE format.
         """
@@ -243,7 +245,7 @@ class LHEParticle:
         self._event: LHEEvent | None = None
 
     @property
-    def event(self) -> "LHEEvent" | None:
+    def event(self) -> LHEEvent | None:
         """
         Reference to the parent event, set when the particle is added to an event.
 
@@ -259,13 +261,13 @@ class LHEParticle:
         return self._event
 
     @event.setter
-    def event(self, value: "LHEEvent" | None) -> None:
+    def event(self, value: LHEEvent | None) -> None:
         """Set the parent event reference."""
         # Previously it was just event so we still allow that for backward compatibility
         self._event = value
 
     @classmethod
-    def fromstring(cls, string: str) -> "LHEParticle":
+    def fromstring(cls, string: str) -> LHEParticle:
         """
         Create an `LHEParticle` instance from a string in LHE format.
         """
@@ -309,7 +311,7 @@ class LHEParticle:
             spin=self.spin,
         )
 
-    def mothers(self) -> list["LHEParticle"]:
+    def mothers(self) -> list[LHEParticle]:
         """
         Return a list of the particle's mothers.
 
@@ -384,7 +386,7 @@ class LHEInitInfo:
         )
 
     @classmethod
-    def fromstring(cls, string: str) -> "LHEInitInfo":
+    def fromstring(cls, string: str) -> LHEInitInfo:
         """
         Create an `LHEInitInfo` instance from a string in LHE format.
         """
@@ -435,7 +437,7 @@ class LHEProcInfo:
         )
 
     @classmethod
-    def fromstring(cls, string: str) -> "LHEProcInfo":
+    def fromstring(cls, string: str) -> LHEProcInfo:
         """
         Create an `LHEProcInfo` instance from a string in LHE format.
         """
@@ -593,7 +595,7 @@ class LHEHeader:
     @classmethod
     def _fromcontext(
         cls, _root: ET.Element, context: Iterator[tuple[str, ET.Element]]
-    ) -> "LHEHeader":
+    ) -> LHEHeader:
         initrwgtentries: list[InitRWGTEntry] = []
         extra_elements: list[ET.Element] = []
         attributes: dict[str, str] = {}
@@ -729,7 +731,7 @@ class LHEInit:
     @classmethod
     def _fromcontext(
         cls, _root: ET.Element, context: Iterator[tuple[str, ET.Element]]
-    ) -> "LHEInit":
+    ) -> LHEInit:
         initInfo = None
         procInfo = []
         generators = []
@@ -848,7 +850,7 @@ class LHEEvent:
         context: Iterator[tuple[str, ET.Element]],
         lheheader: LHEHeader | None = None,
         with_attributes: bool = True,
-    ) -> Iterator["LHEEvent"]:
+    ) -> Iterator[LHEEvent]:
         index_map = (
             lheheader.initrwgt.index_to_id() if with_attributes and lheheader else {}
         )
@@ -1076,7 +1078,7 @@ class LesHouchesEvents:
     @classmethod
     def fromstring(
         cls, string: str, with_attributes: bool = True, generator: bool = True
-    ) -> "LHEFile":
+    ) -> LHEFile:
         """
         Create an LHEFile instance from a string in LHE format.
         """
@@ -1087,7 +1089,7 @@ class LesHouchesEvents:
     @classmethod
     def fromfile(
         cls, filepath: PathLike, with_attributes: bool = True, generator: bool = True
-    ) -> "LHEFile":
+    ) -> LHEFile:
         """
         Read an LHE file and return an LHEFile object.
         """
@@ -1108,7 +1110,7 @@ class LesHouchesEvents:
         | BinaryIO,
         with_attributes: bool = True,
         generator: bool = True,
-    ) -> "LHEFile":
+    ) -> LHEFile:
         """
         Read an LHE file and return an LHEFile object.
         """

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -80,7 +80,7 @@ class LHEFileFormat(enum.Enum):
 
     PLAIN = "plain"
     GZIP = "gzip"
-    HDF5 = "hdf5"  # TODO - for future support of LHEH5, see https://github.com/scikit-hep/pylhe/issues/369
+    HDF5 = "hdf5"  # HDF5-based LHEH5 (consolidated) format
 
 
 @dataclass(frozen=True)

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -188,7 +188,7 @@ class LHEEventInfo:
         Return the event info as a string in LHE XML format.
 
         Returns:
-            str: The event info as a string in LHE format.
+            str: The event info as a string in LHE XML format.
         """
         return lheformat.eventinfo.format(
             nparticles=self.nparticles,
@@ -299,10 +299,10 @@ class LHEParticle:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the particle as a string in LHE format.
+        Return the particle as a string in LHE XML format.
 
         Returns:
-            str: The particle as a string in LHE format.
+            str: The particle as a string in LHE XML format.
         """
         return lheformat.particle.format(
             id=self.id,
@@ -376,10 +376,10 @@ class LHEInitInfo:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the init info block as a string in LHE format.
+        Return the init info block as a string in LHE XML format.
 
         Returns:
-            str: The init info block as a string in LHE format.
+            str: The init info block as a string in LHE XML format.
         """
         return lheformat.initinfo.format(
             beamA=self.beamA,
@@ -433,10 +433,10 @@ class LHEProcInfo:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the process info block as a string in LHE format.
+        Return the process info block as a string in LHE XML format.
 
         Returns:
-            str: The process info block as a string in LHE format.
+            str: The process info block as a string in LHE XML format.
         """
         if self.npLO is not None:
             warnings.warn(
@@ -560,10 +560,10 @@ class LHEInitRWGT:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the init block as a string in LHE format.
+        Return the init block as a string in LHE XML format.
 
         Returns:
-            str: The init block as a string in LHE format.
+            str: The init block as a string in LHE XML format.
         """
         # weightgroups to xml
         root = ET.Element("initrwgt")
@@ -603,7 +603,7 @@ class LHEHeader:
         return {**self.extra_attributes}
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
-        """Return the header block as a string in LHE format."""
+        """Return the header block as a string in LHE XML format."""
         root = ET.Element("header", attrib=self.attributes)
         for element in self.extra_elements:
             root.append(_copy_xml_element(element))
@@ -710,10 +710,10 @@ class LHEGenerator:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:  # noqa: ARG002
         """
-        Return the generator information as a string in LHE format.
+        Return the generator information as a string in LHE XML format.
 
         Returns:
-            str: The generator information as a string in LHE format.
+            str: The generator information as a string in LHE XML format.
         """
         opening_tag = _open_xml_tag("generator", self.attributes)
         return f"{opening_tag}{self.description}</generator>"
@@ -732,10 +732,10 @@ class LHEInit:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the init block as a string in LHE format.
+        Return the init block as a string in LHE XML format.
 
         Returns:
-            str: The init block as a string in LHE format.
+            str: The init block as a string in LHE XML format.
         """
         return (
             "<init>\n"
@@ -819,13 +819,13 @@ class LHEEvent:
 
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
-        Return the event as a string in LHE format.
+        Return the event as a string in LHE XML format.
 
         Args:
-            format (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat` class.
+            lheformat (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat` class.
 
         Returns:
-            str: The event as a string in LHE format.
+            str: The event as a string in LHE XML format.
         """
         sweights = ""
         if lheformat.weights is LHEWeightFormat.RWGT and self.weights:
@@ -1055,6 +1055,14 @@ class LesHouchesEvents:
     ) -> TWriteable:
         """
         Write the LHE file to an output stream.
+
+        Args:
+            output_stream (TWriteable): Output stream to write the LHE file to.
+            lheformat (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat` class.
+
+        Returns:
+            TWriteable: The output stream with the LHE file written to it.
+
         """
         output_stream.write(_open_xml_tag("LesHouchesEvents", self.attributes) + "\n")
         if self.comment is not None:
@@ -1070,6 +1078,9 @@ class LesHouchesEvents:
     def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the LHE file as a string.
+
+        Args:
+            lheformat (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat` class.
         """
         return self.write(io.StringIO(), lheformat=lheformat).getvalue()
 
@@ -1084,7 +1095,7 @@ class LesHouchesEvents:
 
         Args:
             filepath (PathLike): Path to the output file.
-            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat` class.
+            lheformat (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat` class.
         """
         # autodetect default format from suffix if not provided
         if lheformat is None:
@@ -1102,6 +1113,12 @@ class LesHouchesEvents:
     ) -> LHEFile:
         """
         Create an LHEFile instance from a string in LHE format.
+
+        Args:
+            string (str): String containing the LHE file content.
+            with_attributes (bool): Whether to parse attributes from the LHE file. Default is True.
+            generator (bool): Whether to return a generator for events. Default is True.
+
         """
         return cls.frombuffer(
             io.StringIO(string), with_attributes=with_attributes, generator=generator
@@ -1113,6 +1130,12 @@ class LesHouchesEvents:
     ) -> LHEFile:
         """
         Read an LHE file and return an LHEFile object.
+
+        Args:
+            filepath (PathLike): Path to the LHE file.
+            with_attributes (bool): Whether to parse attributes from the LHE file. Default is True.
+            generator (bool): Whether to return a generator for events. Default is True.
+
         """
         return cls.frombuffer(
             _extract_fileobj(filepath),
@@ -1321,7 +1344,11 @@ def _parse_lheformat_from_filepath(
 
 def _open_write_file(filepath: PathLike, lheformat: LHEXMLFormat) -> TextIO:
     """
-    Open a file for writing, determining the format based on the file extension or provided LHEOutputFormat.
+    Open a file for writing, determining the format based on the file extension or provided LHEXMLFormat.
+
+    Args:
+        filepath: A path-like object or str.
+        lheformat: The LHEXMLFormat to use for writing.
     """
     if lheformat.compress:
         return gzip.open(filepath, "wt")

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1309,9 +1309,11 @@ def _extract_fileobj(
     is_hdf5 = False
 
     with open(filepath, "rb") as gzip_file:
+        # GZIP magic number per RFC 1952 section 2.3.1
         is_gzip = gzip_file.read(2) == b"\x1f\x8b"
 
     with open(filepath, "rb") as f:
+        # HDF magic number per The HDF5 Field Guide II.A.
         is_hdf5 = f.read(8) == b"\x89HDF\r\n\x1a\n"
 
     if is_gzip:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -23,6 +23,7 @@ from typing import (
 from xml.sax.saxutils import quoteattr
 
 import graphviz  # type: ignore[import-untyped]
+import h5py  # type: ignore[import-untyped]
 from particle import latex_to_html_name
 from particle.converters.bimap import DirectionalMaps
 from particle.exceptions import MatchingIDNotFound
@@ -78,7 +79,7 @@ class LHEFileFormat(enum.Enum):
 
     PLAIN = "plain"
     GZIP = "gzip"
-    # HDF5 = "hdf5" # TODO - for future support of LHEH5, see https://github.com/scikit-hep/pylhe/issues/369
+    HDF5 = "hdf5"  # TODO - for future support of LHEH5, see https://github.com/scikit-hep/pylhe/issues/369
 
 
 @dataclass(frozen=True)
@@ -1203,7 +1204,9 @@ class LesHouchesEvents:
 LHEFile = LesHouchesEvents
 
 
-def _extract_fileobj(filepath: PathLike) -> Union[io.BufferedReader, gzip.GzipFile]:
+def _extract_fileobj(
+    filepath: PathLike,
+) -> Union[io.BufferedReader, gzip.GzipFile, h5py.File]:
     """
     Checks to see if a file is compressed, and if so, extract it with gzip
     so that the uncompressed file can be returned.
@@ -1214,15 +1217,22 @@ def _extract_fileobj(filepath: PathLike) -> Union[io.BufferedReader, gzip.GzipFi
         filepath: A path-like object or str.
 
     Returns:
-        _io.BufferedReader or gzip.GzipFile: A file object containing XML data.
+        _io.BufferedReader or gzip.GzipFile or h5py.File: A file object containing XML or HDF5 data.
     """
-    with open(filepath, "rb") as gzip_file:
-        header = gzip_file.read(2)
-    gzip_magic_number = b"\x1f\x8b"
+    is_gzip = False
+    is_hdf5 = False
 
-    return (
-        gzip.GzipFile(filepath) if header == gzip_magic_number else open(filepath, "rb")
-    )
+    with open(filepath, "rb") as gzip_file:
+        is_gzip = gzip_file.read(2) == b"\x1f\x8b"
+
+    with open(filepath, "rb") as f:
+        is_hdf5 = f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+    if is_gzip:
+        return gzip.GzipFile(filepath)
+    if is_hdf5:
+        return h5py.File(filepath, "r")
+    return open(filepath, "rb")
 
 
 def _open_write_file(

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -407,6 +407,10 @@ class LHEProcInfo:
     """Unit weight of the process"""
     procId: int
     """Process ID"""
+    npLO: Optional[int] = None
+    """LO final-state multiplicity tag for HDF5 procInfo tables"""
+    npNLO: Optional[int] = None
+    """Born-level multiplicity tag for HDF5 procInfo tables"""
 
     def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
         """
@@ -433,6 +437,8 @@ class LHEProcInfo:
             error=float(values[1]),
             unitWeight=float(values[2]),
             procId=int(float(values[3])),
+            npLO=None,
+            npNLO=None,
         )
 
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1068,7 +1068,7 @@ class LesHouchesEvents:
         if lheformat is None:
             lheformat = _parse_lheformat_from_filepath(filepath)
         if isinstance(lheformat, LHEHDF5Format):
-            with lheh5._open_write_file(filepath) as f:
+            with h5py.File(filepath, "w") as f:
                 lheh5.write(self, f, lheformat=lheformat)
         else:
             with _open_write_file(filepath, lheformat=lheformat) as f:

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
     "LHEEvent",
     "LHEEventInfo",
     "LHEFile",
-    "LHEFileFormat",
     "LHEGenerator",
     "LHEHDF5Format",
     "LHEHeader",
@@ -74,14 +73,6 @@ class LHEWeightFormat(enum.Enum):
     RWGT = "rwgt"  # <rwgt><wgt id=...>...</wgt></rwgt> block
     WEIGHTS = "weights"  # <weights>...</weights> block
     NONE = "none"  # no weights block emitted
-
-
-class LHEFileFormat(enum.Enum):
-    """Selects the file format."""
-
-    PLAIN = "plain"
-    GZIP = "gzip"
-    HDF5 = "hdf5"  # HDF5-based LHEH5 (consolidated) format
 
 
 @dataclass(frozen=True)

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -232,7 +232,7 @@ class LHEParticle:
     def __post_init__(self) -> None:
         """Initialize the event reference."""
         # we store the circular event reference in a private attribute
-        self._event: Optional[LHEEvent] = None
+        self._event: LHEEvent | None = None
 
     @property
     def event(self) -> Optional["LHEEvent"]:
@@ -407,9 +407,9 @@ class LHEProcInfo:
     """Unit weight of the process"""
     procId: int
     """Process ID"""
-    npLO: Optional[int] = None
+    npLO: int | None = None
     """LO final-state multiplicity tag for HDF5 procInfo tables"""
-    npNLO: Optional[int] = None
+    npNLO: int | None = None
     """Born-level multiplicity tag for HDF5 procInfo tables"""
 
     def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
@@ -468,11 +468,11 @@ class LHEInitRWGTWeight:
 class LHEInitRWGTWeightGroup:
     """Information about a weight group."""
 
-    name: Optional[str] = (
+    name: str | None = (
         None  # Normally this is required, i.e. not Optional, but old Madgraph-2.0.0 uses 'type' instead of 'name'...
     )
     """Name of the weight group"""
-    combine: Optional[str] = None
+    combine: str | None = None
     """Combination method of the weight group"""
     weights: list[LHEInitRWGTWeight] = field(default_factory=list)
     """List of weight information"""
@@ -778,7 +778,7 @@ class LHEEvent:
     """Event attributes not represented by dedicated fields"""
     optional: list[str] = field(default_factory=list)
     """Optional '#' comments stored in the event"""
-    _graph: Optional[graphviz.Digraph] = field(default=None, repr=False, compare=False)
+    _graph: graphviz.Digraph | None = field(default=None, repr=False, compare=False)
     """Stores the graph representation of the event generated after first access of the property `lheevent.graph`"""
 
     def __post_init__(self) -> None:
@@ -838,7 +838,7 @@ class LHEEvent:
         cls,
         root: ET.Element,
         context: Iterator[tuple[str, ET.Element]],
-        lheheader: Optional[LHEHeader] = None,
+        lheheader: LHEHeader | None = None,
         with_attributes: bool = True,
     ) -> Iterator["LHEEvent"]:
         index_map = (
@@ -975,8 +975,8 @@ class LHEEvent:
 
     def _repr_mimebundle_(
         self,
-        include: Optional[Iterable[str]] = None,
-        exclude: Optional[Iterable[str]] = None,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
         **kwargs: dict[str, Any],
     ) -> Any:
         """
@@ -995,11 +995,11 @@ class LesHouchesEvents:
     """Init block"""
     events: Iterable[LHEEvent] = field(default_factory=list)
     """Event block"""
-    header: Optional[LHEHeader] = None
+    header: LHEHeader | None = None
     """Header block"""
-    comment: Optional[str] = None
+    comment: str | None = None
     """Comment block"""
-    version: Optional[str] = None
+    version: str | None = None
     """Version of the LHE file"""
     extra_attributes: dict[str, str] = field(default_factory=dict)
     """Attributes of the root LesHouchesEvents element"""
@@ -1088,9 +1088,12 @@ class LesHouchesEvents:
     @classmethod
     def frombuffer(
         cls,
-        fileobject: Union[
-            io.BufferedReader, gzip.GzipFile, h5py.File, io.StringIO, TextIO, BinaryIO
-        ],
+        fileobject: io.BufferedReader
+        | gzip.GzipFile
+        | h5py.File
+        | io.StringIO
+        | TextIO
+        | BinaryIO,
         with_attributes: bool = True,
         generator: bool = True,
     ) -> "LHEFile":
@@ -1229,7 +1232,7 @@ LHEFile = LesHouchesEvents
 
 def _extract_fileobj(
     filepath: PathLike,
-) -> Union[io.BufferedReader, gzip.GzipFile, h5py.File]:
+) -> io.BufferedReader | gzip.GzipFile | h5py.File:
     """
     Checks to see if a file is compressed, and if so, extract it with gzip
     so that the uncompressed file can be returned.
@@ -1260,7 +1263,7 @@ def _extract_fileobj(
 
 def _open_write_file(
     filepath: PathLike, lheformat: LHEOutputFormat = DEFAULT_FORMAT
-) -> Union[TextIO, h5py.File]:
+) -> TextIO | h5py.File:
     filepath_str = os.fsdecode(os.fspath(filepath))
     if (
         filepath_str.endswith((".h5", ".hdf5", "lheh5"))

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     BinaryIO,
-    Optional,
     Protocol,
     TextIO,
     TypeVar,
@@ -244,7 +243,7 @@ class LHEParticle:
         self._event: LHEEvent | None = None
 
     @property
-    def event(self) -> Optional["LHEEvent"]:
+    def event(self) -> "LHEEvent" | None:
         """
         Reference to the parent event, set when the particle is added to an event.
 
@@ -260,7 +259,7 @@ class LHEParticle:
         return self._event
 
     @event.setter
-    def event(self, value: Optional["LHEEvent"]) -> None:
+    def event(self, value: "LHEEvent" | None) -> None:
         """Set the parent event reference."""
         # Previously it was just event so we still allow that for backward compatibility
         self._event = value

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -438,6 +438,18 @@ class LHEProcInfo:
         Returns:
             str: The process info block as a string in LHE format.
         """
+        if self.npLO is not None:
+            warnings.warn(
+                "LHEH5 field npLO has not equivalent in LHE format and will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if self.npNLO is not None:
+            warnings.warn(
+                "LHEH5 field npNLO has not equivalent in LHE format and will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
         return lheformat.procinfo.format(
             xSection=self.xSection,
             error=self.error,

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -28,6 +28,7 @@ from particle import latex_to_html_name
 from particle.converters.bimap import DirectionalMaps
 from particle.exceptions import MatchingIDNotFound
 
+from pylhe import lheh5
 from pylhe._version import version as __version__
 
 __all__ = [
@@ -1079,7 +1080,7 @@ class LesHouchesEvents:
     def frombuffer(
         cls,
         fileobject: Union[
-            io.BufferedReader, gzip.GzipFile, io.StringIO, TextIO, BinaryIO
+            io.BufferedReader, gzip.GzipFile, h5py.File, io.StringIO, TextIO, BinaryIO
         ],
         with_attributes: bool = True,
         generator: bool = True,
@@ -1087,6 +1088,12 @@ class LesHouchesEvents:
         """
         Read an LHE file and return an LHEFile object.
         """
+
+        if isinstance(fileobject, h5py.File):
+            return LesHouchesEvents(
+                init=lheh5.read_init(fileobject),
+                events=lheh5.read_iter_events(fileobject),
+            )
 
         def _generator(lhef: LHEFile) -> Iterator[LHEEvent]:
 

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -18,7 +18,6 @@ from typing import (
     Protocol,
     TextIO,
     TypeVar,
-    Union,
 )
 from xml.sax.saxutils import quoteattr
 
@@ -33,7 +32,7 @@ from pylhe._version import version as __version__
 
 __all__ = [
     "DEFAULT_FORMAT",
-    "GZIP_FORMAT",
+    "GZ_FORMAT",
     "RWGT_FORMAT",
     "RWGT_GZ_FORMAT",
     "WEIGHTS_FORMAT",
@@ -43,6 +42,7 @@ __all__ = [
     "LHEFile",
     "LHEFileFormat",
     "LHEGenerator",
+    "LHEHDF5Format",
     "LHEHeader",
     "LHEInit",
     "LHEInitInfo",
@@ -52,6 +52,7 @@ __all__ = [
     "LHEParticle",
     "LHEProcInfo",
     "LHEWeightFormat",
+    "LHEXMLFormat",
     "__version__",
     "to_awkward",
 ]
@@ -64,7 +65,7 @@ def __dir__() -> list[str]:
 # retrieve mapping of PDG ID to particle name as LaTeX string
 _PDGID2LaTeXNameMap, _ = DirectionalMaps("PDGID", "LATEXNAME", converters=(str, str))
 
-PathLike = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
+PathLike = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 
 
 class LHEWeightFormat(enum.Enum):
@@ -84,13 +85,16 @@ class LHEFileFormat(enum.Enum):
 
 
 @dataclass(frozen=True)
-class LHEOutputFormat:
-    """Future proof, extensible output format"""
+class LHEXMLFormat:
+    """Selects the XML format."""
 
     # version: LHEVersion = LHEVersion.V3 # optional future TODO, but why would anyone not want to write v3?
     indent: str = "  "
+    """indentation string for XML output"""
+    compress: bool = False
+    """compress as gzip"""
+
     weights: LHEWeightFormat = LHEWeightFormat.RWGT
-    file: LHEFileFormat = LHEFileFormat.PLAIN
 
     eventinfo: str = "{nparticles:3d} {pid:6d} {weight: 15.10e} {scale: 15.10e} {aqed: 15.10e} {aqcd: 15.10e}"
     particle: str = "{id:5d} {status:3d} {mother1:3d} {mother2:3d} {color1:3d} {color2:3d} {px: 15.8e} {py: 15.8e} {pz: 15.8e} {e: 15.8e} {m: 15.8e} {lifetime: 10.4e} {spin: 10.4e}"
@@ -98,23 +102,37 @@ class LHEOutputFormat:
     procinfo: str = "{xSection: 14.7e} {error: 14.7e} {unitWeight: 14.7e} {procId: 5d}"
 
 
+@dataclass(frozen=True)
+class LHEHDF5Format:
+    """Selects the HDF5 format."""
+
+    # version
+    compress: bool = False
+    """compress datasets internally via gzip"""
+
+
+LHEOutputFormat = LHEXMLFormat | LHEHDF5Format
+
+
 # User convenience presets for common formats
-DEFAULT_FORMAT = LHEOutputFormat()
+DEFAULT_FORMAT = LHEXMLFormat()
 """Default output format with indentation, RWGT weights block and plain text file format."""
-GZIP_FORMAT = LHEOutputFormat(file=LHEFileFormat.GZIP)
+GZ_FORMAT = LHEXMLFormat(compress=True)
 """Output format for gzip compressed files, with (default) RWGT weights block."""
-RWGT_FORMAT = LHEOutputFormat(weights=LHEWeightFormat.RWGT)
+RWGT_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.RWGT)
 """Output format with RWGT weights block and (default) plain text file format."""
-WEIGHTS_FORMAT = LHEOutputFormat(weights=LHEWeightFormat.WEIGHTS)
+WEIGHTS_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.WEIGHTS)
 """Output format with WEIGHTS weights block and (default) plain text file format."""
-RWGT_GZ_FORMAT = LHEOutputFormat(weights=LHEWeightFormat.RWGT, file=LHEFileFormat.GZIP)
+RWGT_GZ_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.RWGT, compress=True)
 """Output format with RWGT weights block and gzip compressed file format."""
-WEIGHTS_GZ_FORMAT = LHEOutputFormat(
-    weights=LHEWeightFormat.WEIGHTS, file=LHEFileFormat.GZIP
-)
+WEIGHTS_GZ_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.WEIGHTS, compress=True)
 """Output format with WEIGHTS weights block and gzip compressed file format."""
-NO_WEIGHTS_FORMAT = LHEOutputFormat(weights=LHEWeightFormat.NONE)
+NO_WEIGHTS_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.NONE)
 """Output format with no WEIGHTS weights block and (default) plain text file format."""
+HDF5_FORMAT = LHEHDF5Format()
+"""Output format for HDF5-based LHEH5 files."""
+HDF5_GZ_FORMAT = LHEHDF5Format(compress=True)
+"""Output format for HDF5-based LHEH5 files, with optional gzip compression of datasets."""
 
 
 class Writeable(Protocol):
@@ -164,7 +182,7 @@ class LHEEventInfo:
     aqcd: float
     """QCD coupling constant alpha_QCD"""
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the event info as a string in LHE format.
 
@@ -278,7 +296,7 @@ class LHEParticle:
             spin=float(values[12]),
         )
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the particle as a string in LHE format.
 
@@ -325,7 +343,7 @@ class LHEParticle:
         ]
 
 
-def _indent(root: ET.Element, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> None:
+def _indent(root: ET.Element, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> None:
     ET.indent(root, space=lheformat.indent)
     root.tail = "\n"
 
@@ -355,7 +373,7 @@ class LHEInitInfo:
     numProcesses: int
     """Number of processes"""
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the init info block as a string in LHE format.
 
@@ -412,7 +430,7 @@ class LHEProcInfo:
     npNLO: int | None = None
     """Born-level multiplicity tag for HDF5 procInfo tables"""
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the process info block as a string in LHE format.
 
@@ -500,7 +518,7 @@ class LHEInitRWGTWeightGroup:
             self.combine = combine
 
 
-InitRWGTEntry = Union[LHEInitRWGTWeight, LHEInitRWGTWeightGroup]
+InitRWGTEntry = LHEInitRWGTWeight | LHEInitRWGTWeightGroup
 
 
 @dataclass
@@ -527,7 +545,7 @@ class LHEInitRWGT:
         """Return a dictionary mapping weight indices to weight IDs for all weights in the <initrwgt> block."""
         return {i: w.id for i, w in enumerate(self.iter_weights())}
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the init block as a string in LHE format.
 
@@ -571,7 +589,7 @@ class LHEHeader:
         """Return all the attributes of the header element"""
         return {**self.extra_attributes}
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """Return the header block as a string in LHE format."""
         root = ET.Element("header", attrib=self.attributes)
         for element in self.extra_elements:
@@ -677,7 +695,7 @@ class LHEGenerator:
         self.extra_attributes.pop("name", None)
         self.extra_attributes.pop("version", None)
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:  # noqa: ARG002
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:  # noqa: ARG002
         """
         Return the generator information as a string in LHE format.
 
@@ -699,7 +717,7 @@ class LHEInit:
     generators: list[LHEGenerator]
     """Generator information"""
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the init block as a string in LHE format.
 
@@ -786,12 +804,12 @@ class LHEEvent:
         for p in self.particles:
             p.event = self
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the event as a string in LHE format.
 
         Args:
-            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat Enum`.
+            format (LHEXMLFormat): How to serialize the event, see the `LHEXMLFormat Enum`.
 
         Returns:
             str: The event as a string in LHE format.
@@ -1020,7 +1038,7 @@ class LesHouchesEvents:
         return {**self.extra_attributes, **attrs}
 
     def write(
-        self, output_stream: TWriteable, lheformat: LHEOutputFormat = DEFAULT_FORMAT
+        self, output_stream: TWriteable, lheformat: LHEXMLFormat = DEFAULT_FORMAT
     ) -> TWriteable:
         """
         Write the LHE file to an output stream.
@@ -1036,7 +1054,7 @@ class LesHouchesEvents:
         output_stream.write("</LesHouchesEvents>")
         return output_stream
 
-    def tolhe(self, lheformat: LHEOutputFormat = DEFAULT_FORMAT) -> str:
+    def tolhe(self, lheformat: LHEXMLFormat = DEFAULT_FORMAT) -> str:
         """
         Return the LHE file as a string.
         """
@@ -1045,20 +1063,24 @@ class LesHouchesEvents:
     def tofile(
         self,
         filepath: PathLike,
-        lheformat: LHEOutputFormat = DEFAULT_FORMAT,
+        lheformat: LHEOutputFormat
+        | None = None,  # default format is None because we do file name suffix detection in _open_write_file
     ) -> None:
         """
         Write the LHE file.
 
         Args:
             filepath (PathLike): Path to the output file.
-            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat Enum`.
+            format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat`.
         """
         # if filepath suffix is gz, write as gz
-        with _open_write_file(filepath, lheformat=lheformat) as f:
-            if isinstance(f, h5py.File):
-                lheh5.write(self, f)
-            else:
+        if lheformat is None:
+            lheformat = _parse_lheformat_from_filepath(filepath)
+        if isinstance(lheformat, LHEHDF5Format):
+            with lheh5._open_write_file(filepath) as f:
+                lheh5.write(self, filepath, lheformat=lheformat)
+        else:
+            with _open_write_file(filepath, lheformat=lheformat) as f:
                 self.write(f, lheformat=lheformat)
 
     @classmethod
@@ -1261,18 +1283,34 @@ def _extract_fileobj(
     return open(filepath, "rb")
 
 
-def _open_write_file(
-    filepath: PathLike, lheformat: LHEOutputFormat = DEFAULT_FORMAT
-) -> TextIO | h5py.File:
+def _parse_lheformat_from_filepath(
+    filepath: PathLike,
+) -> LHEOutputFormat:
+    """
+    Determine the LHEOutputFormat based on the file extension.
+
+    Args:
+        filepath: A path-like object or str.
+
+    Returns:
+        LHEOutputFormat: The determined output format.
+    """
     filepath_str = os.fsdecode(os.fspath(filepath))
-    if (
-        filepath_str.endswith((".h5", ".hdf5", "lheh5"))
-        or lheformat.file == LHEFileFormat.HDF5
-    ):
-        return h5py.File(filepath_str, "w")
-    if filepath_str.endswith((".gz", ".gzip")) or lheformat.file == LHEFileFormat.GZIP:
-        return gzip.open(filepath_str, "wt")
-    return open(filepath_str, "w")
+    # TODO think about potential .hdf5.gz
+    if filepath_str.endswith((".h5", ".hdf5", "lheh5")):
+        return HDF5_FORMAT
+    if filepath_str.endswith((".gz", ".gzip")):
+        return GZ_FORMAT
+    return DEFAULT_FORMAT
+
+
+def _open_write_file(filepath: PathLike, lheformat: LHEXMLFormat) -> TextIO:
+    """
+    Open a file for writing, determining the format based on the file extension or provided LHEOutputFormat.
+    """
+    if lheformat.compress:
+        return gzip.open(filepath, "wt")
+    return open(filepath, "w")
 
 
 # we import this later to avoid circular imports

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -34,6 +34,8 @@ from pylhe._version import version as __version__
 __all__ = [
     "DEFAULT_FORMAT",
     "GZ_FORMAT",
+    "HDF5_FORMAT",
+    "HDF5_GZ_FORMAT",
     "RWGT_FORMAT",
     "RWGT_GZ_FORMAT",
     "WEIGHTS_FORMAT",

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1050,7 +1050,10 @@ class LesHouchesEvents:
         """
         # if filepath suffix is gz, write as gz
         with _open_write_file(filepath, lheformat=lheformat) as f:
-            self.write(f, lheformat=lheformat)
+            if isinstance(f, h5py.File):
+                lheh5.write(self, f)
+            else:
+                self.write(f, lheformat=lheformat)
 
     @classmethod
     def fromstring(
@@ -1090,9 +1093,16 @@ class LesHouchesEvents:
         """
 
         if isinstance(fileobject, h5py.File):
+            init = lheh5.read_init(fileobject)
+
+            def _hdf5_generator() -> Iterator[LHEEvent]:
+                with fileobject as h5:
+                    yield from lheh5.read_iter_events(h5)
+
+            events = _hdf5_generator()
             return LesHouchesEvents(
-                init=lheh5.read_init(fileobject),
-                events=lheh5.read_iter_events(fileobject),
+                init=init,
+                events=events if generator else list(events),
             )
 
         def _generator(lhef: LHEFile) -> Iterator[LHEEvent]:
@@ -1244,8 +1254,13 @@ def _extract_fileobj(
 
 def _open_write_file(
     filepath: PathLike, lheformat: LHEOutputFormat = DEFAULT_FORMAT
-) -> TextIO:
+) -> Union[TextIO, h5py.File]:
     filepath_str = os.fsdecode(os.fspath(filepath))
+    if (
+        filepath_str.endswith((".h5", ".hdf5", "lheh5"))
+        or lheformat.file == LHEFileFormat.HDF5
+    ):
+        return h5py.File(filepath_str, "w")
     if filepath_str.endswith((".gz", ".gzip")) or lheformat.file == LHEFileFormat.GZIP:
         return gzip.open(filepath_str, "wt")
     return open(filepath_str, "w")

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1078,7 +1078,7 @@ class LesHouchesEvents:
             lheformat = _parse_lheformat_from_filepath(filepath)
         if isinstance(lheformat, LHEHDF5Format):
             with lheh5._open_write_file(filepath) as f:
-                lheh5.write(self, filepath, lheformat=lheformat)
+                lheh5.write(self, f, lheformat=lheformat)
         else:
             with _open_write_file(filepath, lheformat=lheformat) as f:
                 self.write(f, lheformat=lheformat)

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -100,9 +100,16 @@ class LHEXMLFormat:
 class LHEHDF5Format:
     """Selects the HDF5 format."""
 
-    # version
-    compress: bool = False
-    """compress datasets internally via gzip"""
+    compression: str | None = None
+    """Dataset compression filter passed to h5py, e.g. ``\"gzip\"``."""
+    compression_opts: int | None = None
+    """Optional compression level/options passed to h5py."""
+    shuffle: bool = False
+    """Whether to enable the HDF5 shuffle filter."""
+    event_chunk_rows: int = 1024
+    """Chunk size in rows for the events dataset."""
+    particle_chunk_rows: int = 8192
+    """Chunk size in rows for the particles dataset."""
 
 
 LHEOutputFormat = LHEXMLFormat | LHEHDF5Format
@@ -125,8 +132,8 @@ NO_WEIGHTS_FORMAT = LHEXMLFormat(weights=LHEWeightFormat.NONE)
 """Output format with no WEIGHTS weights block and (default) plain text file format."""
 HDF5_FORMAT = LHEHDF5Format()
 """Output format for HDF5-based LHEH5 files."""
-HDF5_GZ_FORMAT = LHEHDF5Format(compress=True)
-"""Output format for HDF5-based LHEH5 files, with optional gzip compression of datasets."""
+HDF5_GZ_FORMAT = LHEHDF5Format(compression="gzip", compression_opts=4, shuffle=True)
+"""Output format for HDF5-based LHEH5 files with gzip-compressed datasets."""
 
 
 class Writeable(Protocol):

--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -1086,7 +1086,7 @@ class LesHouchesEvents:
             filepath (PathLike): Path to the output file.
             format (LHEOutputFormat): How to serialize the event, see the `LHEOutputFormat`.
         """
-        # if filepath suffix is gz, write as gz
+        # autodetect default format from suffix if not provided
         if lheformat is None:
             lheformat = _parse_lheformat_from_filepath(filepath)
         if isinstance(lheformat, LHEHDF5Format):
@@ -1244,6 +1244,8 @@ class LesHouchesEvents:
         """
         try:
             with _extract_fileobj(filepath) as fileobj:
+                if isinstance(fileobj, h5py.File):
+                    return lheh5.count_events(fileobj)
                 context = ET.iterparse(fileobj, events=["start", "end"])
                 _, root = next(context)  # Get the root element
                 count = 0

--- a/src/pylhe/awkward.py
+++ b/src/pylhe/awkward.py
@@ -3,7 +3,6 @@
 """
 
 from collections.abc import Iterable
-from typing import Union
 
 import awkward as ak  # type: ignore[import-untyped]
 import vector
@@ -17,7 +16,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def to_awkward(event_iterable: Union[Iterable[LHEEvent], LHEFile]) -> ak.Array:
+def to_awkward(event_iterable: Iterable[LHEEvent] | LHEFile) -> ak.Array:
     """Convert an iterable of LHEEvent instances to an Awkward-Array.
 
     Uses Awkward's ArrayBuilder to construct the array by iterating over the events.

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -17,7 +17,16 @@ from collections.abc import Iterable, Iterator, Sequence
 
 import h5py  # type: ignore[import-untyped]
 
-import pylhe
+from pylhe import (
+    LesHouchesEvents,
+    LHEEvent,
+    LHEEventInfo,
+    LHEHDF5Format,
+    LHEInit,
+    LHEInitInfo,
+    LHEParticle,
+    LHEProcInfo,
+)
 
 _PARTICLE_COLUMNS = (
     "id",
@@ -164,7 +173,7 @@ def _set_column_attrs(dataset: h5py.Dataset, columns: Iterable[str]) -> None:
 
 
 def _dataset_write_args(
-    lheformat: pylhe.LHEHDF5Format, *, chunk_rows: int, ncolumns: int
+    lheformat: LHEHDF5Format, *, chunk_rows: int, ncolumns: int
 ) -> dict[str, object]:
     args: dict[str, object] = {"chunks": (chunk_rows, ncolumns)}
 
@@ -206,7 +215,7 @@ def _append_rows(dataset: h5py.Dataset, rows: list[list[float]]) -> None:
     dataset[start:stop] = rows
 
 
-def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> float:
+def _event_scale(event: LHEEvent, *names: str, default: float = 0.0) -> float:
     for name in names:
         value = event.scales.get(name)
         if value is not None:
@@ -215,7 +224,7 @@ def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> fl
     return default
 
 
-def _event_trials(event: pylhe.LHEEvent) -> float:
+def _event_trials(event: LHEEvent) -> float:
     trials = event.attributes.get("trials")
     if trials is None:
         return 0.0
@@ -226,14 +235,12 @@ def _event_trials(event: pylhe.LHEEvent) -> float:
         return 0.0
 
 
-def get_particles(
-    particles: h5py.Dataset, start: int, n: int
-) -> list[pylhe.LHEParticle]:
+def get_particles(particles: h5py.Dataset, start: int, n: int) -> list[LHEParticle]:
     """Get a list of LHEParticle objects from a particles dataset."""
     particle_columns = _column_indices(particles, default=_PARTICLE_COLUMNS)
 
     return [
-        pylhe.LHEParticle(
+        LHEParticle(
             id=_row_int(row, particle_columns, "id"),
             status=_row_int(row, particle_columns, "status"),
             mother1=_row_int(row, particle_columns, "mother1"),
@@ -258,7 +265,7 @@ def count_events(file: h5py.File) -> int:
     return len(events)
 
 
-def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
+def read_iter_events(file: h5py.File) -> Iterator[LHEEvent]:
     """Read events from an HDF5 file in LHEH5 format."""
     events = file["events"]
     particles = file["particles"]
@@ -280,8 +287,8 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
         if not math.isnan(rscale):
             scales["rscale"] = rscale
 
-        yield pylhe.LHEEvent(
-            eventinfo=pylhe.LHEEventInfo(
+        yield LHEEvent(
+            eventinfo=LHEEventInfo(
                 nparticles=nparticles,
                 pid=_row_int(event_row, event_columns, "pid"),
                 weight=_row_float(
@@ -303,7 +310,7 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
         )
 
 
-def read_init(file: h5py.File) -> pylhe.LHEInit:
+def read_init(file: h5py.File) -> LHEInit:
     """Read the init and procInfo datasets from an HDF5 file in LHEH5 format."""
     init = file["init"]
     procinfo = file["procInfo"]
@@ -311,8 +318,8 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
     procinfo_columns = _column_indices(procinfo, default=_PROCINFO_COLUMNS)
     init_row = init[()]
 
-    return pylhe.LHEInit(
-        initInfo=pylhe.LHEInitInfo(
+    return LHEInit(
+        initInfo=LHEInitInfo(
             beamA=_row_int(init_row, init_columns, "beamA"),
             beamB=_row_int(init_row, init_columns, "beamB"),
             energyA=_row_float(init_row, init_columns, "energyA"),
@@ -325,7 +332,7 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
             numProcesses=_row_int(init_row, init_columns, "numProcesses"),
         ),
         procInfo=[
-            pylhe.LHEProcInfo(
+            LHEProcInfo(
                 xSection=_row_float(row, procinfo_columns, "xSection"),
                 error=_row_float(row, procinfo_columns, "error"),
                 unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
@@ -339,9 +346,7 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
     )
 
 
-def write(
-    lhe: pylhe.LesHouchesEvents, file: h5py.File, lheformat: pylhe.LHEHDF5Format
-) -> None:
+def write(lhe: LesHouchesEvents, file: h5py.File, lheformat: LHEHDF5Format) -> None:
     """Write a LesHouchesEvents object to an HDF5 file in LHEH5 format."""
     proc_info = lhe.init.procInfo
     init_info = lhe.init.initInfo

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -19,16 +19,7 @@ from collections.abc import Iterable, Iterator, Sequence
 
 import h5py  # type: ignore[import-untyped]
 
-from pylhe import (
-    LesHouchesEvents,
-    LHEEvent,
-    LHEEventInfo,
-    LHEHDF5Format,
-    LHEInit,
-    LHEInitInfo,
-    LHEParticle,
-    LHEProcInfo,
-)
+import pylhe
 
 _LHEH5_VERSION = (2, 0, 0)
 
@@ -177,7 +168,7 @@ def _set_column_attrs(dataset: h5py.Dataset, columns: Iterable[str]) -> None:
 
 
 def _dataset_write_args(
-    lheformat: LHEHDF5Format, *, chunk_rows: int, ncolumns: int
+    lheformat: pylhe.LHEHDF5Format, *, chunk_rows: int, ncolumns: int
 ) -> dict[str, object]:
     args: dict[str, object] = {"chunks": (chunk_rows, ncolumns)}
 
@@ -219,7 +210,7 @@ def _append_rows(dataset: h5py.Dataset, rows: list[list[float]]) -> None:
     dataset[start:stop] = rows
 
 
-def _event_scale(event: LHEEvent, *names: str, default: float = 0.0) -> float:
+def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> float:
     for name in names:
         value = event.scales.get(name)
         if value is not None:
@@ -228,7 +219,7 @@ def _event_scale(event: LHEEvent, *names: str, default: float = 0.0) -> float:
     return default
 
 
-def _event_trials(event: LHEEvent) -> float:
+def _event_trials(event: pylhe.LHEEvent) -> float:
     trials = event.attributes.get("trials")
     if trials is None:
         return 0.0
@@ -239,12 +230,14 @@ def _event_trials(event: LHEEvent) -> float:
         return 0.0
 
 
-def get_particles(particles: h5py.Dataset, start: int, n: int) -> list[LHEParticle]:
+def get_particles(
+    particles: h5py.Dataset, start: int, n: int
+) -> list[pylhe.LHEParticle]:
     """Get a list of LHEParticle objects from a particles dataset."""
     particle_columns = _column_indices(particles, default=_PARTICLE_COLUMNS)
 
     return [
-        LHEParticle(
+        pylhe.LHEParticle(
             id=_row_int(row, particle_columns, "id"),
             status=_row_int(row, particle_columns, "status"),
             mother1=_row_int(row, particle_columns, "mother1"),
@@ -269,7 +262,7 @@ def count_events(file: h5py.File) -> int:
     return len(events)
 
 
-def read_iter_events(file: h5py.File) -> Iterator[LHEEvent]:
+def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
     """Read events from an HDF5 file in LHEH5 format."""
     events = file["events"]
     particles = file["particles"]
@@ -291,8 +284,8 @@ def read_iter_events(file: h5py.File) -> Iterator[LHEEvent]:
         if not math.isnan(rscale):
             scales["rscale"] = rscale
 
-        yield LHEEvent(
-            eventinfo=LHEEventInfo(
+        yield pylhe.LHEEvent(
+            eventinfo=pylhe.LHEEventInfo(
                 nparticles=nparticles,
                 pid=_row_int(event_row, event_columns, "pid"),
                 weight=_row_float(
@@ -314,7 +307,7 @@ def read_iter_events(file: h5py.File) -> Iterator[LHEEvent]:
         )
 
 
-def read_init(file: h5py.File) -> LHEInit:
+def read_init(file: h5py.File) -> pylhe.LHEInit:
     """Read the init and procInfo datasets from an HDF5 file in LHEH5 format."""
     init = file["init"]
     procinfo = file["procInfo"]
@@ -322,8 +315,8 @@ def read_init(file: h5py.File) -> LHEInit:
     procinfo_columns = _column_indices(procinfo, default=_PROCINFO_COLUMNS)
     init_row = init[()]
 
-    return LHEInit(
-        initInfo=LHEInitInfo(
+    return pylhe.LHEInit(
+        initInfo=pylhe.LHEInitInfo(
             beamA=_row_int(init_row, init_columns, "beamA"),
             beamB=_row_int(init_row, init_columns, "beamB"),
             energyA=_row_float(init_row, init_columns, "energyA"),
@@ -336,7 +329,7 @@ def read_init(file: h5py.File) -> LHEInit:
             numProcesses=_row_int(init_row, init_columns, "numProcesses"),
         ),
         procInfo=[
-            LHEProcInfo(
+            pylhe.LHEProcInfo(
                 xSection=_row_float(row, procinfo_columns, "xSection"),
                 error=_row_float(row, procinfo_columns, "error"),
                 unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
@@ -350,7 +343,9 @@ def read_init(file: h5py.File) -> LHEInit:
     )
 
 
-def write(lhe: LesHouchesEvents, file: h5py.File, lheformat: LHEHDF5Format) -> None:
+def write(
+    lhe: pylhe.LesHouchesEvents, file: h5py.File, lheformat: pylhe.LHEHDF5Format
+) -> None:
     """Write a LesHouchesEvents object to an HDF5 file in LHEH5 format."""
     proc_info = lhe.init.procInfo
     init_info = lhe.init.initInfo

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -277,7 +277,9 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
     )
 
 
-def write(lhe: pylhe.LesHouchesEvents, file: h5py.File) -> None:
+def write(
+    lhe: pylhe.LesHouchesEvents, file: h5py.File, lheformat: pylhe.LHEHDF5Format
+) -> None:
     """Write a LesHouchesEvents object to an HDF5 file in LHEH5 format."""
     events = list(lhe.events)
     proc_info = lhe.init.procInfo
@@ -377,11 +379,22 @@ def write(lhe: pylhe.LesHouchesEvents, file: h5py.File) -> None:
         )
         start += nparticles
 
+    compression_args = {}
+    if lheformat.compress:
+        compression_args = {
+            "compression": "gzip",
+            "compression_opts": 4,
+            "shuffle": True,
+        }
+
     events_dataset = file.create_dataset(
         "events",
         data=event_rows or None,
         shape=(len(event_rows), len(_EVENT_COLUMNS)),
         dtype="f8",
+        # Optional parameters for better compression and performance
+        chunks=True,
+        **compression_args,
     )
     _set_column_attrs(events_dataset, _EVENT_COLUMNS)
 
@@ -390,7 +403,17 @@ def write(lhe: pylhe.LesHouchesEvents, file: h5py.File) -> None:
         data=particle_rows or None,
         shape=(len(particle_rows), len(_PARTICLE_COLUMNS)),
         dtype="f8",
+        # Optional parameters for better compression and performance
+        chunks=True,
+        **compression_args,
     )
     _set_column_attrs(particles_dataset, _PARTICLE_COLUMNS)
 
     file.create_dataset("version", data=_LHEH5_VERSION, dtype="i8")
+
+
+def _open_write_file(filepath: pylhe.PathLike) -> h5py.File:
+    """
+    Open a file for writing, determining the format based on the file extension or provided LHEOutputFormat.
+    """
+    return h5py.File(filepath, "w")

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -44,6 +44,21 @@ _PROCINFO_COLUMNS = (
     "unitWeight",
 )
 
+_EVENT_COLUMNS = (
+    "pid",
+    "nparticles",
+    "start",
+    "trials",
+    "scale",
+    "fscale",
+    "rscale",
+    "aqed",
+    "aqcd",
+    "NOMINAL",
+)
+
+_LHEH5_VERSION = (1, 0, 0)
+
 
 def _decode_attr_values(values: Iterable[object]) -> list[str]:
     return [
@@ -98,6 +113,37 @@ def _row_float(
     raise KeyError(err)
 
 
+def _encode_attr_values(values: Iterable[str]) -> list[bytes]:
+    return [value.encode() for value in values]
+
+
+def _set_column_attrs(dataset: h5py.Dataset, columns: Iterable[str]) -> None:
+    encoded = _encode_attr_values(columns)
+    dataset_name = dataset.name.rsplit("/", maxsplit=1)[-1]
+    dataset.attrs["properties"] = encoded
+    dataset.attrs[dataset_name] = encoded
+
+
+def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> float:
+    for name in names:
+        value = event.scales.get(name)
+        if value is not None:
+            return float(value)
+
+    return default
+
+
+def _event_trials(event: pylhe.LHEEvent) -> float:
+    trials = event.attributes.get("trials")
+    if trials is None:
+        return 0.0
+
+    try:
+        return float(trials)
+    except ValueError:
+        return 0.0
+
+
 def _get_particles(
     particles: h5py.Dataset, start: int, n: int
 ) -> list[pylhe.LHEParticle]:
@@ -130,32 +176,31 @@ def get_particles(
 
 
 def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
-    with file as h5:
-        events = h5["events"]
-        particles = h5["particles"]
-        event_columns = _column_indices(events)
+    events = file["events"]
+    particles = file["particles"]
+    event_columns = _column_indices(events)
 
-        for event_row in events:
-            start = _row_int(event_row, event_columns, "start")
-            nparticles = _row_int(event_row, event_columns, "nparticles")
+    for event_row in events:
+        start = _row_int(event_row, event_columns, "start")
+        nparticles = _row_int(event_row, event_columns, "nparticles")
 
-            yield pylhe.LHEEvent(
-                eventinfo=pylhe.LHEEventInfo(
-                    nparticles=nparticles,
-                    pid=_row_int(event_row, event_columns, "pid"),
-                    weight=_row_float(
-                        event_row,
-                        event_columns,
-                        "weight",
-                        "NOMINAL",
-                        default=0.0,
-                    ),
-                    scale=_row_float(event_row, event_columns, "scale", default=0.0),
-                    aqed=_row_float(event_row, event_columns, "aqed", default=0.0),
-                    aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
+        yield pylhe.LHEEvent(
+            eventinfo=pylhe.LHEEventInfo(
+                nparticles=nparticles,
+                pid=_row_int(event_row, event_columns, "pid"),
+                weight=_row_float(
+                    event_row,
+                    event_columns,
+                    "weight",
+                    "NOMINAL",
+                    default=0.0,
                 ),
-                particles=_get_particles(particles, start, nparticles),
-            )
+                scale=_row_float(event_row, event_columns, "scale", default=0.0),
+                aqed=_row_float(event_row, event_columns, "aqed", default=0.0),
+                aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
+            ),
+            particles=_get_particles(particles, start, nparticles),
+        )
 
 
 def iter_lheh5(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
@@ -163,34 +208,145 @@ def iter_lheh5(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
 
 
 def read_init(file: h5py.File) -> pylhe.LHEInit:
-    with file as h5:
-        init = h5["init"]
-        procinfo = h5["procInfo"]
-        init_columns = _column_indices(init, default=_INIT_COLUMNS)
-        procinfo_columns = _column_indices(procinfo, default=_PROCINFO_COLUMNS)
-        init_row = init[()]
+    init = file["init"]
+    procinfo = file["procInfo"]
+    init_columns = _column_indices(init, default=_INIT_COLUMNS)
+    procinfo_columns = _column_indices(procinfo, default=_PROCINFO_COLUMNS)
+    init_row = init[()]
 
-        return pylhe.LHEInit(
-            initInfo=pylhe.LHEInitInfo(
-                beamA=_row_int(init_row, init_columns, "beamA"),
-                beamB=_row_int(init_row, init_columns, "beamB"),
-                energyA=_row_float(init_row, init_columns, "energyA"),
-                energyB=_row_float(init_row, init_columns, "energyB"),
-                PDFgroupA=_row_int(init_row, init_columns, "PDFgroupA"),
-                PDFgroupB=_row_int(init_row, init_columns, "PDFgroupB"),
-                PDFsetA=_row_int(init_row, init_columns, "PDFsetA"),
-                PDFsetB=_row_int(init_row, init_columns, "PDFsetB"),
-                weightingStrategy=_row_int(init_row, init_columns, "weightingStrategy"),
-                numProcesses=_row_int(init_row, init_columns, "numProcesses"),
-            ),
-            procInfo=[
-                pylhe.LHEProcInfo(
-                    xSection=_row_float(row, procinfo_columns, "xSection"),
-                    error=_row_float(row, procinfo_columns, "error"),
-                    unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
-                    procId=_row_int(row, procinfo_columns, "procId"),
-                )
-                for row in procinfo
-            ],
-            generators=[],
+    return pylhe.LHEInit(
+        initInfo=pylhe.LHEInitInfo(
+            beamA=_row_int(init_row, init_columns, "beamA"),
+            beamB=_row_int(init_row, init_columns, "beamB"),
+            energyA=_row_float(init_row, init_columns, "energyA"),
+            energyB=_row_float(init_row, init_columns, "energyB"),
+            PDFgroupA=_row_int(init_row, init_columns, "PDFgroupA"),
+            PDFgroupB=_row_int(init_row, init_columns, "PDFgroupB"),
+            PDFsetA=_row_int(init_row, init_columns, "PDFsetA"),
+            PDFsetB=_row_int(init_row, init_columns, "PDFsetB"),
+            weightingStrategy=_row_int(init_row, init_columns, "weightingStrategy"),
+            numProcesses=_row_int(init_row, init_columns, "numProcesses"),
+        ),
+        procInfo=[
+            pylhe.LHEProcInfo(
+                xSection=_row_float(row, procinfo_columns, "xSection"),
+                error=_row_float(row, procinfo_columns, "error"),
+                unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
+                procId=_row_int(row, procinfo_columns, "procId"),
+            )
+            for row in procinfo
+        ],
+        generators=[],
+    )
+
+
+def write(lhe: pylhe.LesHouchesEvents, file: h5py.File) -> None:
+    """Write a LesHouchesEvents object to an HDF5 file in LHEH5 format."""
+    events = list(lhe.events)
+    proc_info = lhe.init.procInfo
+    init_info = lhe.init.initInfo
+
+    if init_info.numProcesses != len(proc_info):
+        err = (
+            "initInfo.numProcesses does not match the number of procInfo rows: "
+            f"{init_info.numProcesses} != {len(proc_info)}"
         )
+        raise ValueError(err)
+
+    init_dataset = file.create_dataset(
+        "init",
+        data=[
+            init_info.beamA,
+            init_info.beamB,
+            init_info.energyA,
+            init_info.energyB,
+            init_info.PDFgroupA,
+            init_info.PDFgroupB,
+            init_info.PDFsetA,
+            init_info.PDFsetB,
+            init_info.weightingStrategy,
+            init_info.numProcesses,
+        ],
+        dtype="f8",
+    )
+    _set_column_attrs(init_dataset, _INIT_COLUMNS)
+
+    proc_rows = [
+        [proc.procId, 0.0, 0.0, proc.xSection, proc.error, proc.unitWeight]
+        for proc in proc_info
+    ]
+    proc_dataset = file.create_dataset(
+        "procInfo",
+        data=proc_rows or None,
+        shape=(len(proc_rows), len(_PROCINFO_COLUMNS)),
+        dtype="f8",
+    )
+    _set_column_attrs(proc_dataset, _PROCINFO_COLUMNS)
+
+    particle_rows: list[list[float]] = []
+    event_rows: list[list[float]] = []
+    start = 0
+
+    for event in events:
+        nparticles = len(event.particles)
+        if event.eventinfo.nparticles != nparticles:
+            err = (
+                "eventinfo.nparticles does not match the number of particle rows: "
+                f"{event.eventinfo.nparticles} != {nparticles}"
+            )
+            raise ValueError(err)
+
+        event_rows.append(
+            [
+                event.eventinfo.pid,
+                nparticles,
+                start,
+                _event_trials(event),
+                event.eventinfo.scale,
+                _event_scale(event, "fscale", "muf"),
+                _event_scale(event, "rscale", "mur"),
+                event.eventinfo.aqed,
+                event.eventinfo.aqcd,
+                event.eventinfo.weight,
+            ]
+        )
+
+        particle_rows.extend(
+            [
+                [
+                    particle.id,
+                    particle.status,
+                    particle.mother1,
+                    particle.mother2,
+                    particle.color1,
+                    particle.color2,
+                    particle.px,
+                    particle.py,
+                    particle.pz,
+                    particle.e,
+                    particle.m,
+                    particle.lifetime,
+                    particle.spin,
+                ]
+                for particle in event.particles
+            ]
+        )
+        start += nparticles
+
+    events_dataset = file.create_dataset(
+        "events",
+        data=event_rows or None,
+        shape=(len(event_rows), len(_EVENT_COLUMNS)),
+        dtype="f8",
+    )
+    _set_column_attrs(events_dataset, _EVENT_COLUMNS)
+
+    particles_dataset = file.create_dataset(
+        "particles",
+        data=particle_rows or None,
+        shape=(len(particle_rows), len(_PARTICLE_COLUMNS)),
+        dtype="f8",
+    )
+    _set_column_attrs(particles_dataset, _PARTICLE_COLUMNS)
+
+    file.create_dataset("version", data=_LHEH5_VERSION, dtype="i8")

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -1,6 +1,8 @@
 """
 LHEH5 format reader for reading LHE files in HDF5 format.
 
+Note: We do not support ctparticles and ctevents datasets as of now.
+
 References:
     - Stefan Hoeche, Stefan Prestel, and Holger Schulz,
       "Simulation of vector boson plus many jet final states at the high luminosity LHC",
@@ -27,6 +29,10 @@ from pylhe import (
     LHEParticle,
     LHEProcInfo,
 )
+
+_LHEH5_VERSION = (2, 0, 0)
+
+# Below column names are used for reading and writing datasets in LHEH5 format v2.
 
 _PARTICLE_COLUMNS = (
     "id",
@@ -78,8 +84,6 @@ _EVENT_COLUMNS = (
     "aqcd",
     "NOMINAL",
 )
-
-_LHEH5_VERSION = (2, 0, 0)
 
 
 def _decode_attr_values(values: Iterable[object]) -> list[str]:

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -200,9 +200,10 @@ def _event_trials(event: pylhe.LHEEvent) -> float:
         return 0.0
 
 
-def _get_particles(
+def get_particles(
     particles: h5py.Dataset, start: int, n: int
 ) -> list[pylhe.LHEParticle]:
+    """Get a list of LHEParticle objects from a particles dataset."""
     particle_columns = _column_indices(particles, default=_PARTICLE_COLUMNS)
 
     return [
@@ -225,13 +226,8 @@ def _get_particles(
     ]
 
 
-def get_particles(
-    particles: h5py.Dataset, start: int, n: int
-) -> list[pylhe.LHEParticle]:
-    return _get_particles(particles, start, n)
-
-
 def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
+    """Read events from an HDF5 file in LHEH5 format."""
     events = file["events"]
     particles = file["particles"]
     event_columns = _column_indices(events)
@@ -267,17 +263,14 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
                 aqed=_row_float(event_row, event_columns, "aqed", default=0.0),
                 aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
             ),
-            particles=_get_particles(particles, start, nparticles),
+            particles=get_particles(particles, start, nparticles),
             scales=scales,
             attributes=attributes,
         )
 
 
-def iter_lheh5(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
-    yield from read_iter_events(file)
-
-
 def read_init(file: h5py.File) -> pylhe.LHEInit:
+    """Read the init and procInfo datasets from an HDF5 file in LHEH5 format."""
     init = file["init"]
     procinfo = file["procInfo"]
     init_columns = _column_indices(init, default=_INIT_COLUMNS)
@@ -451,10 +444,3 @@ def write(
     _flush_pending_rows()
 
     file.create_dataset("version", data=_LHEH5_VERSION, dtype="i8")
-
-
-def _open_write_file(filepath: pylhe.PathLike) -> h5py.File:
-    """
-    Open a file for writing, determining the format based on the file extension or provided LHEOutputFormat.
-    """
-    return h5py.File(filepath, "w")

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -14,6 +14,7 @@ References:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable, Iterator, Sequence
 
 import h5py  # type: ignore[import-untyped]
@@ -120,6 +121,24 @@ def _row_int(
 
     err = f"None of the requested columns are available: {', '.join(names)}"
     raise KeyError(err)
+
+
+def _row_int_or_none(
+    row: Sequence[float],
+    columns: dict[str, int],
+    *names: str,
+    default: int | None = None,
+) -> int | None:
+    for name in names:
+        index = columns.get(name)
+        if index is not None and index < len(row):
+            float_value = float(row[index])
+            # check if is nan
+            if math.isnan(float_value):
+                return None
+            return int(float_value)
+
+    return default
 
 
 def _row_float(
@@ -244,7 +263,7 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
     """Read events from an HDF5 file in LHEH5 format."""
     events = file["events"]
     particles = file["particles"]
-    event_columns = _column_indices(events)
+    event_columns = _column_indices(events, default=_EVENT_COLUMNS)
 
     for event_row in events:
         start = _row_int(event_row, event_columns, "start")
@@ -310,16 +329,8 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
                 error=_row_float(row, procinfo_columns, "error"),
                 unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
                 procId=_row_int(row, procinfo_columns, "procId"),
-                npLO=(
-                    _row_int(row, procinfo_columns, "npLO")
-                    if _row_has_column(row, procinfo_columns, "npLO")
-                    else None
-                ),
-                npNLO=(
-                    _row_int(row, procinfo_columns, "npNLO")
-                    if _row_has_column(row, procinfo_columns, "npNLO")
-                    else None
-                ),
+                npLO=(_row_int_or_none(row, procinfo_columns, "npLO")),
+                npNLO=(_row_int_or_none(row, procinfo_columns, "npNLO")),
             )
             for row in procinfo
         ],
@@ -362,8 +373,8 @@ def write(
     proc_rows = [
         [
             proc.procId,
-            0.0 if proc.npLO is None else proc.npLO,
-            0.0 if proc.npNLO is None else proc.npNLO,
+            float("nan") if proc.npLO is None else proc.npLO,
+            float("nan") if proc.npNLO is None else proc.npNLO,
             proc.xSection,
             proc.error,
             proc.unitWeight,

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -58,6 +58,8 @@ _EVENT_COLUMNS = (
 )
 
 _LHEH5_VERSION = (2, 0, 0)
+_EVENT_CHUNK_ROWS = 1024
+_PARTICLE_CHUNK_ROWS = 8192
 
 
 def _decode_attr_values(values: Iterable[object]) -> list[str]:
@@ -135,6 +137,47 @@ def _set_column_attrs(dataset: h5py.Dataset, columns: Iterable[str]) -> None:
     dataset_name = dataset.name.rsplit("/", maxsplit=1)[-1]
     dataset.attrs["properties"] = encoded
     dataset.attrs[dataset_name] = encoded
+
+
+def _compression_args(lheformat: pylhe.LHEHDF5Format) -> dict[str, object]:
+    if not lheformat.compress:
+        return {}
+
+    return {
+        "compression": "gzip",
+        "compression_opts": 4,
+        "shuffle": True,
+    }
+
+
+def _create_row_dataset(
+    file: h5py.File,
+    name: str,
+    columns: tuple[str, ...],
+    *,
+    chunk_rows: int,
+    compression_args: dict[str, object],
+) -> h5py.Dataset:
+    dataset = file.create_dataset(
+        name,
+        shape=(0, len(columns)),
+        maxshape=(None, len(columns)),
+        dtype="f8",
+        chunks=(chunk_rows, len(columns)),
+        **compression_args,
+    )
+    _set_column_attrs(dataset, columns)
+    return dataset
+
+
+def _append_rows(dataset: h5py.Dataset, rows: list[list[float]]) -> None:
+    if not rows:
+        return
+
+    start = dataset.shape[0]
+    stop = start + len(rows)
+    dataset.resize((stop, dataset.shape[1]))
+    dataset[start:stop] = rows
 
 
 def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> float:
@@ -281,7 +324,6 @@ def write(
     lhe: pylhe.LesHouchesEvents, file: h5py.File, lheformat: pylhe.LHEHDF5Format
 ) -> None:
     """Write a LesHouchesEvents object to an HDF5 file in LHEH5 format."""
-    events = list(lhe.events)
     proc_info = lhe.init.procInfo
     init_info = lhe.init.initInfo
 
@@ -329,11 +371,33 @@ def write(
     )
     _set_column_attrs(proc_dataset, _PROCINFO_COLUMNS)
 
+    compression_args = _compression_args(lheformat)
+    events_dataset = _create_row_dataset(
+        file,
+        "events",
+        _EVENT_COLUMNS,
+        chunk_rows=_EVENT_CHUNK_ROWS,
+        compression_args=compression_args,
+    )
+    particles_dataset = _create_row_dataset(
+        file,
+        "particles",
+        _PARTICLE_COLUMNS,
+        chunk_rows=_PARTICLE_CHUNK_ROWS,
+        compression_args=compression_args,
+    )
+
     particle_rows: list[list[float]] = []
     event_rows: list[list[float]] = []
     start = 0
 
-    for event in events:
+    def _flush_pending_rows() -> None:
+        _append_rows(events_dataset, event_rows)
+        _append_rows(particles_dataset, particle_rows)
+        event_rows.clear()
+        particle_rows.clear()
+
+    for event in lhe.events:
         nparticles = len(event.particles)
         if event.eventinfo.nparticles != nparticles:
             err = (
@@ -378,36 +442,13 @@ def write(
             ]
         )
         start += nparticles
+        if (
+            len(event_rows) >= _EVENT_CHUNK_ROWS
+            or len(particle_rows) >= _PARTICLE_CHUNK_ROWS
+        ):
+            _flush_pending_rows()
 
-    compression_args = {}
-    if lheformat.compress:
-        compression_args = {
-            "compression": "gzip",
-            "compression_opts": 4,
-            "shuffle": True,
-        }
-
-    events_dataset = file.create_dataset(
-        "events",
-        data=event_rows or None,
-        shape=(len(event_rows), len(_EVENT_COLUMNS)),
-        dtype="f8",
-        # Optional parameters for better compression and performance
-        chunks=True,
-        **compression_args,
-    )
-    _set_column_attrs(events_dataset, _EVENT_COLUMNS)
-
-    particles_dataset = file.create_dataset(
-        "particles",
-        data=particle_rows or None,
-        shape=(len(particle_rows), len(_PARTICLE_COLUMNS)),
-        dtype="f8",
-        # Optional parameters for better compression and performance
-        chunks=True,
-        **compression_args,
-    )
-    _set_column_attrs(particles_dataset, _PARTICLE_COLUMNS)
+    _flush_pending_rows()
 
     file.create_dataset("version", data=_LHEH5_VERSION, dtype="i8")
 

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -269,17 +269,17 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
     for event_row in events:
         start = _row_int(event_row, event_columns, "start")
         nparticles = _row_int(event_row, event_columns, "nparticles")
-        trials = _row_float(event_row, event_columns, "trials", default=0.0)
-        fscale = _row_float(event_row, event_columns, "fscale", default=0.0)
-        rscale = _row_float(event_row, event_columns, "rscale", default=0.0)
+        trials = _row_float(event_row, event_columns, "trials", default=float("nan"))
+        fscale = _row_float(event_row, event_columns, "fscale", default=float("nan"))
+        rscale = _row_float(event_row, event_columns, "rscale", default=float("nan"))
         attributes: dict[str, str] = {}
         scales: dict[str, float] = {}
 
-        if trials != 0.0:
+        if not math.isnan(trials):
             attributes["trials"] = str(trials)
-        if fscale != 0.0:
+        if not math.isnan(fscale):
             scales["fscale"] = fscale
-        if rscale != 0.0:
+        if not math.isnan(rscale):
             scales["rscale"] = rscale
 
         yield pylhe.LHEEvent(
@@ -293,9 +293,11 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
                     "NOMINAL",
                     default=0.0,
                 ),
-                scale=_row_float(event_row, event_columns, "scale", default=0.0),
-                aqed=_row_float(event_row, event_columns, "aqed", default=0.0),
-                aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
+                scale=_row_float(
+                    event_row, event_columns, "scale", default=float("nan")
+                ),
+                aqed=_row_float(event_row, event_columns, "aqed", default=float("nan")),
+                aqcd=_row_float(event_row, event_columns, "aqcd", default=float("nan")),
             ),
             particles=get_particles(particles, start, nparticles),
             scales=scales,

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -57,7 +57,7 @@ _EVENT_COLUMNS = (
     "NOMINAL",
 )
 
-_LHEH5_VERSION = (1, 0, 0)
+_LHEH5_VERSION = (2, 0, 0)
 
 
 def _decode_attr_values(values: Iterable[object]) -> list[str]:

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -100,11 +100,6 @@ def _column_indices(
     }
 
 
-def _row_has_column(row: Sequence[float], columns: dict[str, int], name: str) -> bool:
-    index = columns.get(name)
-    return index is not None and index < len(row)
-
-
 def _row_int(
     row: Sequence[float],
     columns: dict[str, int],

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -1,3 +1,17 @@
+"""
+LHEH5 format reader for reading LHE files in HDF5 format.
+
+References:
+    - Stefan Hoeche, Stefan Prestel, and Holger Schulz,
+      "Simulation of vector boson plus many jet final states at the high
+      luminosity LHC", arXiv:1905.05120
+      (https://arxiv.org/pdf/1905.05120)
+    - Enrico Bothmann et al.,
+      "Efficient precision simulation of processes with many-jet final states
+      at the LHC", arXiv:2309.13154
+      (https://arxiv.org/pdf/2309.13154)
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Sequence

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -85,11 +85,24 @@ def _column_indices(
     }
 
 
-def _row_int(row: Sequence[float], columns: dict[str, int], *names: str) -> int:
+def _row_has_column(row: Sequence[float], columns: dict[str, int], name: str) -> bool:
+    index = columns.get(name)
+    return index is not None and index < len(row)
+
+
+def _row_int(
+    row: Sequence[float],
+    columns: dict[str, int],
+    *names: str,
+    default: int | None = None,
+) -> int:
     for name in names:
         index = columns.get(name)
-        if index is not None:
+        if index is not None and index < len(row):
             return int(float(row[index]))
+
+    if default is not None:
+        return default
 
     err = f"None of the requested columns are available: {', '.join(names)}"
     raise KeyError(err)
@@ -103,7 +116,7 @@ def _row_float(
 ) -> float:
     for name in names:
         index = columns.get(name)
-        if index is not None:
+        if index is not None and index < len(row):
             return float(row[index])
 
     if default is not None:
@@ -183,6 +196,18 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
     for event_row in events:
         start = _row_int(event_row, event_columns, "start")
         nparticles = _row_int(event_row, event_columns, "nparticles")
+        trials = _row_float(event_row, event_columns, "trials", default=0.0)
+        fscale = _row_float(event_row, event_columns, "fscale", default=0.0)
+        rscale = _row_float(event_row, event_columns, "rscale", default=0.0)
+        attributes: dict[str, str] = {}
+        scales: dict[str, float] = {}
+
+        if trials != 0.0:
+            attributes["trials"] = str(trials)
+        if fscale != 0.0:
+            scales["fscale"] = fscale
+        if rscale != 0.0:
+            scales["rscale"] = rscale
 
         yield pylhe.LHEEvent(
             eventinfo=pylhe.LHEEventInfo(
@@ -200,6 +225,8 @@ def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
                 aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
             ),
             particles=_get_particles(particles, start, nparticles),
+            scales=scales,
+            attributes=attributes,
         )
 
 
@@ -233,6 +260,16 @@ def read_init(file: h5py.File) -> pylhe.LHEInit:
                 error=_row_float(row, procinfo_columns, "error"),
                 unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
                 procId=_row_int(row, procinfo_columns, "procId"),
+                npLO=(
+                    _row_int(row, procinfo_columns, "npLO")
+                    if _row_has_column(row, procinfo_columns, "npLO")
+                    else None
+                ),
+                npNLO=(
+                    _row_int(row, procinfo_columns, "npNLO")
+                    if _row_has_column(row, procinfo_columns, "npNLO")
+                    else None
+                ),
             )
             for row in procinfo
         ],
@@ -272,7 +309,14 @@ def write(lhe: pylhe.LesHouchesEvents, file: h5py.File) -> None:
     _set_column_attrs(init_dataset, _INIT_COLUMNS)
 
     proc_rows = [
-        [proc.procId, 0.0, 0.0, proc.xSection, proc.error, proc.unitWeight]
+        [
+            proc.procId,
+            0.0 if proc.npLO is None else proc.npLO,
+            0.0 if proc.npNLO is None else proc.npNLO,
+            proc.xSection,
+            proc.error,
+            proc.unitWeight,
+        ]
         for proc in proc_info
     ]
     proc_dataset = file.create_dataset(

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -72,8 +72,6 @@ _EVENT_COLUMNS = (
 )
 
 _LHEH5_VERSION = (2, 0, 0)
-_EVENT_CHUNK_ROWS = 1024
-_PARTICLE_CHUNK_ROWS = 8192
 
 
 def _decode_attr_values(values: Iterable[object]) -> list[str]:
@@ -153,15 +151,19 @@ def _set_column_attrs(dataset: h5py.Dataset, columns: Iterable[str]) -> None:
     dataset.attrs[dataset_name] = encoded
 
 
-def _compression_args(lheformat: pylhe.LHEHDF5Format) -> dict[str, object]:
-    if not lheformat.compress:
-        return {}
+def _dataset_write_args(
+    lheformat: pylhe.LHEHDF5Format, *, chunk_rows: int, ncolumns: int
+) -> dict[str, object]:
+    args: dict[str, object] = {"chunks": (chunk_rows, ncolumns)}
 
-    return {
-        "compression": "gzip",
-        "compression_opts": 4,
-        "shuffle": True,
-    }
+    if lheformat.compression is not None:
+        args["compression"] = lheformat.compression
+    if lheformat.compression_opts is not None:
+        args["compression_opts"] = lheformat.compression_opts
+    if lheformat.shuffle:
+        args["shuffle"] = True
+
+    return args
 
 
 def _create_row_dataset(
@@ -169,16 +171,14 @@ def _create_row_dataset(
     name: str,
     columns: tuple[str, ...],
     *,
-    chunk_rows: int,
-    compression_args: dict[str, object],
+    write_args: dict[str, object],
 ) -> h5py.Dataset:
     dataset = file.create_dataset(
         name,
         shape=(0, len(columns)),
         maxshape=(None, len(columns)),
         dtype="f8",
-        chunks=(chunk_rows, len(columns)),
-        **compression_args,
+        **write_args,
     )
     _set_column_attrs(dataset, columns)
     return dataset
@@ -378,20 +378,27 @@ def write(
     )
     _set_column_attrs(proc_dataset, _PROCINFO_COLUMNS)
 
-    compression_args = _compression_args(lheformat)
+    events_write_args = _dataset_write_args(
+        lheformat,
+        chunk_rows=lheformat.event_chunk_rows,
+        ncolumns=len(_EVENT_COLUMNS),
+    )
     events_dataset = _create_row_dataset(
         file,
         "events",
         _EVENT_COLUMNS,
-        chunk_rows=_EVENT_CHUNK_ROWS,
-        compression_args=compression_args,
+        write_args=events_write_args,
+    )
+    particles_write_args = _dataset_write_args(
+        lheformat,
+        chunk_rows=lheformat.particle_chunk_rows,
+        ncolumns=len(_PARTICLE_COLUMNS),
     )
     particles_dataset = _create_row_dataset(
         file,
         "particles",
         _PARTICLE_COLUMNS,
-        chunk_rows=_PARTICLE_CHUNK_ROWS,
-        compression_args=compression_args,
+        write_args=particles_write_args,
     )
 
     particle_rows: list[list[float]] = []
@@ -450,8 +457,8 @@ def write(
         )
         start += nparticles
         if (
-            len(event_rows) >= _EVENT_CHUNK_ROWS
-            or len(particle_rows) >= _PARTICLE_CHUNK_ROWS
+            len(event_rows) >= lheformat.event_chunk_rows
+            or len(particle_rows) >= lheformat.particle_chunk_rows
         ):
             _flush_pending_rows()
 

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -3,13 +3,11 @@ LHEH5 format reader for reading LHE files in HDF5 format.
 
 References:
     - Stefan Hoeche, Stefan Prestel, and Holger Schulz,
-      "Simulation of vector boson plus many jet final states at the high
-      luminosity LHC", arXiv:1905.05120
-      (https://arxiv.org/pdf/1905.05120)
+      "Simulation of vector boson plus many jet final states at the high luminosity LHC",
+      arXiv:1905.05120 (https://arxiv.org/pdf/1905.05120)
     - Enrico Bothmann et al.,
-      "Efficient precision simulation of processes with many-jet final states
-      at the LHC", arXiv:2309.13154
-      (https://arxiv.org/pdf/2309.13154)
+      "Efficient precision simulation of processes with many-jet final states at the LHC",
+      arXiv:2309.13154 (https://arxiv.org/pdf/2309.13154)
 """
 
 from __future__ import annotations

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
+
+import h5py  # type: ignore[import-untyped]
+
+import pylhe
+
+_PARTICLE_COLUMNS = (
+    "id",
+    "status",
+    "mother1",
+    "mother2",
+    "color1",
+    "color2",
+    "px",
+    "py",
+    "pz",
+    "e",
+    "m",
+    "lifetime",
+    "spin",
+)
+
+_INIT_COLUMNS = (
+    "beamA",
+    "beamB",
+    "energyA",
+    "energyB",
+    "PDFgroupA",
+    "PDFgroupB",
+    "PDFsetA",
+    "PDFsetB",
+    "weightingStrategy",
+    "numProcesses",
+)
+
+_PROCINFO_COLUMNS = (
+    "procId",
+    "npLO",
+    "npNLO",
+    "xSection",
+    "error",
+    "unitWeight",
+)
+
+
+def _decode_attr_values(values: Iterable[object]) -> list[str]:
+    return [
+        value.decode() if isinstance(value, bytes) else str(value) for value in values
+    ]
+
+
+def _column_names(dataset: h5py.Dataset, *, default: tuple[str, ...] = ()) -> list[str]:
+    attr_names = ("properties", dataset.name.rsplit("/", maxsplit=1)[-1])
+
+    for attr_name in attr_names:
+        if attr_name in dataset.attrs:
+            return _decode_attr_values(dataset.attrs[attr_name])
+
+    return list(default)
+
+
+def _column_indices(
+    dataset: h5py.Dataset, *, default: tuple[str, ...] = ()
+) -> dict[str, int]:
+    return {
+        name: index
+        for index, name in enumerate(_column_names(dataset, default=default))
+    }
+
+
+def _row_int(row: Sequence[float], columns: dict[str, int], *names: str) -> int:
+    for name in names:
+        index = columns.get(name)
+        if index is not None:
+            return int(float(row[index]))
+
+    err = f"None of the requested columns are available: {', '.join(names)}"
+    raise KeyError(err)
+
+
+def _row_float(
+    row: Sequence[float],
+    columns: dict[str, int],
+    *names: str,
+    default: float | None = None,
+) -> float:
+    for name in names:
+        index = columns.get(name)
+        if index is not None:
+            return float(row[index])
+
+    if default is not None:
+        return default
+
+    err = f"None of the requested columns are available: {', '.join(names)}"
+    raise KeyError(err)
+
+
+def _get_particles(
+    particles: h5py.Dataset, start: int, n: int
+) -> list[pylhe.LHEParticle]:
+    particle_columns = _column_indices(particles, default=_PARTICLE_COLUMNS)
+
+    return [
+        pylhe.LHEParticle(
+            id=_row_int(row, particle_columns, "id"),
+            status=_row_int(row, particle_columns, "status"),
+            mother1=_row_int(row, particle_columns, "mother1"),
+            mother2=_row_int(row, particle_columns, "mother2"),
+            color1=_row_int(row, particle_columns, "color1"),
+            color2=_row_int(row, particle_columns, "color2"),
+            px=_row_float(row, particle_columns, "px"),
+            py=_row_float(row, particle_columns, "py"),
+            pz=_row_float(row, particle_columns, "pz"),
+            e=_row_float(row, particle_columns, "e"),
+            m=_row_float(row, particle_columns, "m"),
+            lifetime=_row_float(row, particle_columns, "lifetime"),
+            spin=_row_float(row, particle_columns, "spin"),
+        )
+        for row in particles[start : start + n]
+    ]
+
+
+def get_particles(
+    particles: h5py.Dataset, start: int, n: int
+) -> list[pylhe.LHEParticle]:
+    return _get_particles(particles, start, n)
+
+
+def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
+    with file as h5:
+        events = h5["events"]
+        particles = h5["particles"]
+        event_columns = _column_indices(events)
+
+        for event_row in events:
+            start = _row_int(event_row, event_columns, "start")
+            nparticles = _row_int(event_row, event_columns, "nparticles")
+
+            yield pylhe.LHEEvent(
+                eventinfo=pylhe.LHEEventInfo(
+                    nparticles=nparticles,
+                    pid=_row_int(event_row, event_columns, "pid"),
+                    weight=_row_float(
+                        event_row,
+                        event_columns,
+                        "weight",
+                        "NOMINAL",
+                        default=0.0,
+                    ),
+                    scale=_row_float(event_row, event_columns, "scale", default=0.0),
+                    aqed=_row_float(event_row, event_columns, "aqed", default=0.0),
+                    aqcd=_row_float(event_row, event_columns, "aqcd", default=0.0),
+                ),
+                particles=_get_particles(particles, start, nparticles),
+            )
+
+
+def iter_lheh5(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
+    yield from read_iter_events(file)
+
+
+def read_init(file: h5py.File) -> pylhe.LHEInit:
+    with file as h5:
+        init = h5["init"]
+        procinfo = h5["procInfo"]
+        init_columns = _column_indices(init, default=_INIT_COLUMNS)
+        procinfo_columns = _column_indices(procinfo, default=_PROCINFO_COLUMNS)
+        init_row = init[()]
+
+        return pylhe.LHEInit(
+            initInfo=pylhe.LHEInitInfo(
+                beamA=_row_int(init_row, init_columns, "beamA"),
+                beamB=_row_int(init_row, init_columns, "beamB"),
+                energyA=_row_float(init_row, init_columns, "energyA"),
+                energyB=_row_float(init_row, init_columns, "energyB"),
+                PDFgroupA=_row_int(init_row, init_columns, "PDFgroupA"),
+                PDFgroupB=_row_int(init_row, init_columns, "PDFgroupB"),
+                PDFsetA=_row_int(init_row, init_columns, "PDFsetA"),
+                PDFsetB=_row_int(init_row, init_columns, "PDFsetB"),
+                weightingStrategy=_row_int(init_row, init_columns, "weightingStrategy"),
+                numProcesses=_row_int(init_row, init_columns, "numProcesses"),
+            ),
+            procInfo=[
+                pylhe.LHEProcInfo(
+                    xSection=_row_float(row, procinfo_columns, "xSection"),
+                    error=_row_float(row, procinfo_columns, "error"),
+                    unitWeight=_row_float(row, procinfo_columns, "unitWeight"),
+                    procId=_row_int(row, procinfo_columns, "procId"),
+                )
+                for row in procinfo
+            ],
+            generators=[],
+        )

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -259,6 +259,12 @@ def get_particles(
     ]
 
 
+def count_events(file: h5py.File) -> int:
+    """Count the number of events in an HDF5 file in LHEH5 format."""
+    events = file["events"]
+    return len(events)
+
+
 def read_iter_events(file: h5py.File) -> Iterator[pylhe.LHEEvent]:
     """Read events from an HDF5 file in LHEH5 format."""
     events = file["events"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,6 @@ def test_top_level_api():
         "LHEEvent",
         "LHEEventInfo",
         "LHEFile",
-        "LHEFileFormat",
         "LHEGenerator",
         "LHEHDF5Format",
         "LHEHeader",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,12 +4,13 @@ import pylhe
 def test_top_level_api():
     assert dir(pylhe) == [
         "DEFAULT_FORMAT",
-        "GZIP_FORMAT",
+        "GZ_FORMAT",
         "LHEEvent",
         "LHEEventInfo",
         "LHEFile",
         "LHEFileFormat",
         "LHEGenerator",
+        "LHEHDF5Format",
         "LHEHeader",
         "LHEInit",
         "LHEInitInfo",
@@ -19,6 +20,7 @@ def test_top_level_api():
         "LHEParticle",
         "LHEProcInfo",
         "LHEWeightFormat",
+        "LHEXMLFormat",
         "RWGT_FORMAT",
         "RWGT_GZ_FORMAT",
         "WEIGHTS_FORMAT",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,8 @@ def test_top_level_api():
     assert dir(pylhe) == [
         "DEFAULT_FORMAT",
         "GZ_FORMAT",
+        "HDF5_FORMAT",
+        "HDF5_GZ_FORMAT",
         "LHEEvent",
         "LHEEventInfo",
         "LHEFile",

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -186,6 +186,8 @@ def test_LHEProcInfo_fromstring():
         "error": 0.089185414,
         "unitWeight": 50.109093,
         "procId": 66.0,
+        "npLO": None,
+        "npNLO": None,
     }
     assert dataclasses.asdict(LHEProcInfo.fromstring(data)) == result
 
@@ -202,16 +204,22 @@ def test_LHEProcInfo_backwards_compatibility():
     assert proc_info.error == pytest.approx(0.089185414)
     assert proc_info.unitWeight == pytest.approx(50.109093)
     assert proc_info.procId == pytest.approx(66.0)
+    assert proc_info.npLO is None
+    assert proc_info.npNLO is None
 
     proc_info.xSection = 60.0
     proc_info.error = 0.1
     proc_info.unitWeight = 60.0
     proc_info.procId = 67.0
+    proc_info.npLO = 1
+    proc_info.npNLO = 2
 
     assert proc_info.xSection == pytest.approx(60.0)
     assert proc_info.error == pytest.approx(0.1)
     assert proc_info.unitWeight == pytest.approx(60.0)
     assert proc_info.procId == pytest.approx(67.0)
+    assert proc_info.npLO == 1
+    assert proc_info.npNLO == 2
 
 
 def test_LHEInitRWGTWeight_init_with_id_argument():

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pylhe
+
+
+def _make_repetitive_lhe(num_events: int = 256) -> pylhe.LesHouchesEvents:
+    template_event = pylhe.LHEEvent(
+        eventinfo=pylhe.LHEEventInfo(
+            nparticles=3,
+            pid=7,
+            weight=2.5,
+            scale=91.2,
+            aqed=0.01,
+            aqcd=0.11,
+        ),
+        particles=[
+            pylhe.LHEParticle(
+                11,
+                -1,
+                0,
+                0,
+                501,
+                0,
+                0.0,
+                0.0,
+                50.0,
+                50.0,
+                0.0,
+                0.0,
+                1.0,
+            ),
+            pylhe.LHEParticle(
+                -11,
+                -1,
+                0,
+                0,
+                0,
+                501,
+                0.0,
+                0.0,
+                -50.0,
+                50.0,
+                0.0,
+                0.0,
+                -1.0,
+            ),
+            pylhe.LHEParticle(
+                22,
+                1,
+                1,
+                2,
+                0,
+                0,
+                0.0,
+                0.0,
+                0.0,
+                100.0,
+                100.0,
+                0.0,
+                0.0,
+            ),
+        ],
+        scales={"fscale": 88.0, "rscale": 94.0},
+        attributes={"trials": "12.0"},
+    )
+
+    return pylhe.LesHouchesEvents(
+        init=pylhe.LHEInit(
+            initInfo=pylhe.LHEInitInfo(
+                beamA=11,
+                beamB=-11,
+                energyA=100.0,
+                energyB=100.0,
+                PDFgroupA=0,
+                PDFgroupB=0,
+                PDFsetA=0,
+                PDFsetB=0,
+                weightingStrategy=1,
+                numProcesses=1,
+            ),
+            procInfo=[
+                pylhe.LHEProcInfo(
+                    xSection=1.5,
+                    error=0.1,
+                    unitWeight=1.0,
+                    procId=7,
+                    npLO=2,
+                    npNLO=1,
+                )
+            ],
+            generators=[],
+        ),
+        events=[deepcopy(template_event) for _ in range(num_events)],
+    )
+
+
+def test_xml_gzip_output_is_smaller_than_plain(tmp_path):
+    lhe = _make_repetitive_lhe()
+    plain_path = tmp_path / "events.lhe"
+    gzip_path = tmp_path / "events.lhe.gz"
+
+    lhe.tofile(plain_path)
+    lhe.tofile(gzip_path, lheformat=pylhe.GZ_FORMAT)
+
+    assert gzip_path.stat().st_size < plain_path.stat().st_size
+
+
+def test_hdf5_compressed_output_is_smaller_than_uncompressed(tmp_path):
+    lhe = _make_repetitive_lhe()
+    plain_path = tmp_path / "events-uncompressed.hdf5"
+    compressed_path = tmp_path / "events-compressed.hdf5"
+
+    lhe.tofile(plain_path, lheformat=pylhe.HDF5_FORMAT)
+    lhe.tofile(compressed_path, lheformat=pylhe.HDF5_GZ_FORMAT)
+
+    assert compressed_path.stat().st_size < plain_path.stat().st_size

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,6 +4,7 @@ import tempfile
 import xml.etree.ElementTree as ET
 from tempfile import NamedTemporaryFile
 
+import h5py
 import pytest
 
 import pylhe
@@ -69,6 +70,51 @@ def test_missing_init_block_error_with_file():
             pylhe.LesHouchesEvents.fromfile(tmp_file_path)
     finally:
         os.unlink(tmp_file_path)
+
+
+def test_lheh5_row_int_raises_for_missing_columns():
+    with pytest.raises(
+        KeyError, match=r"None of the requested columns are available: pid, start"
+    ):
+        pylhe.lheh5._row_int([], {}, "pid", "start")
+
+
+def test_lheh5_row_float_raises_for_missing_columns():
+    with pytest.raises(
+        KeyError, match=r"None of the requested columns are available: scale, aqed"
+    ):
+        pylhe.lheh5._row_float([], {}, "scale", "aqed")
+
+
+def test_lheh5_event_trials_returns_zero_for_missing_or_invalid_trials():
+    missing_trials_event = pylhe.LHEEvent(
+        eventinfo=pylhe.LHEEventInfo(0, 0, 0.0, 0.0, 0.0, 0.0),
+        particles=[],
+    )
+    invalid_trials_event = pylhe.LHEEvent(
+        eventinfo=pylhe.LHEEventInfo(0, 0, 0.0, 0.0, 0.0, 0.0),
+        particles=[],
+        attributes={"trials": "not-a-float"},
+    )
+
+    assert pylhe.lheh5._event_trials(missing_trials_event) == 0.0
+    assert pylhe.lheh5._event_trials(invalid_trials_event) == 0.0
+
+
+def test_lheh5_append_rows_returns_early_for_empty_rows(tmp_path):
+    path = tmp_path / "empty-append.hdf5"
+
+    with h5py.File(path, "w") as h5:
+        dataset = h5.create_dataset(
+            "rows",
+            shape=(0, 2),
+            maxshape=(None, 2),
+            dtype="f8",
+            chunks=(2, 2),
+        )
+        pylhe.lheh5._append_rows(dataset, [])
+
+        assert dataset.shape == (0, 2)
 
 
 def test_missing_init_block_error_with_only_events():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -86,6 +86,33 @@ def test_lheh5_row_float_raises_for_missing_columns():
         pylhe.lheh5._row_float([], {}, "scale", "aqed")
 
 
+def test_lheh5_row_int_returns_default_for_missing_columns():
+    assert pylhe.lheh5._row_int([], {}, "pid", "start", default=7) == 7
+
+
+def test_lheh5_row_float_returns_default_for_missing_columns():
+    assert pylhe.lheh5._row_float([], {}, "scale", "aqed", default=3.5) == 3.5
+
+
+def test_lheh5_column_names_returns_default_when_attrs_missing(tmp_path):
+    path = tmp_path / "missing-column-names.hdf5"
+
+    with h5py.File(path, "w") as h5:
+        dataset = h5.create_dataset("rows", data=[[1.0, 2.0]], dtype="f8")
+
+        assert pylhe.lheh5._column_names(dataset, default=("a", "b")) == ["a", "b"]
+
+
+def test_lheh5_event_scale_returns_default_when_names_missing():
+    event = pylhe.LHEEvent(
+        eventinfo=pylhe.LHEEventInfo(0, 0, 0.0, 0.0, 0.0, 0.0),
+        particles=[],
+        scales={"other": 12.0},
+    )
+
+    assert pylhe.lheh5._event_scale(event, "fscale", "muf", default=9.5) == 9.5
+
+
 def test_lheh5_event_trials_returns_zero_for_missing_or_invalid_trials():
     missing_trials_event = pylhe.LHEEvent(
         eventinfo=pylhe.LHEEventInfo(0, 0, 0.0, 0.0, 0.0, 0.0),

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -90,6 +90,14 @@ def test_lheh5_row_int_returns_default_for_missing_columns():
     assert pylhe.lheh5._row_int([], {}, "pid", "start", default=7) == 7
 
 
+def test_lheh5_row_int_or_none_returns_none_for_nan():
+    assert pylhe.lheh5._row_int_or_none([float("nan")], {"npLO": 0}, "npLO") is None
+
+
+def test_lheh5_row_int_or_none_returns_default_for_missing_columns():
+    assert pylhe.lheh5._row_int_or_none([], {}, "npLO", default=7) == 7
+
+
 def test_lheh5_row_float_returns_default_for_missing_columns():
     assert pylhe.lheh5._row_float([], {}, "scale", "aqed", default=3.5) == 3.5
 

--- a/tests/test_lhe_writer.py
+++ b/tests/test_lhe_writer.py
@@ -338,7 +338,7 @@ def test_tofile_none_format_emits_no_weight_block(tmp_path):
     file.events = [next(events)]
 
     file.tofile(
-        out_path, lheformat=pylhe.LHEOutputFormat(weights=pylhe.LHEWeightFormat.NONE)
+        out_path, lheformat=pylhe.LHEXMLFormat(weights=pylhe.LHEWeightFormat.NONE)
     )
 
     content = out_path.read_text()

--- a/tests/test_lhe_writer.py
+++ b/tests/test_lhe_writer.py
@@ -257,7 +257,7 @@ def test_write_lhe_gzip(tmpdir):
     events = [next(events)]
 
     # write the file
-    file.tofile(file1.strpath, lheformat=pylhe.GZIP_FORMAT)
+    file.tofile(file1.strpath, lheformat=pylhe.GZ_FORMAT)
 
     # read it again
     init = pylhe.LesHouchesEvents.fromfile(file1.strpath).init

--- a/tests/test_lheh5_reader.py
+++ b/tests/test_lheh5_reader.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import pytest
+
+import pylhe
+from pylhe.lheh5 import get_particles, iter_lheh5, read_init
+
+TEST_HDF5 = Path(__file__).with_name("test.hdf5")
+TEST_HDF5_J7 = Path(__file__).with_name("j7_1.hdf5")
+
+
+def test_get_particles_returns_lheparticles():
+    with h5py.File(TEST_HDF5, "r") as h5:
+        particles = get_particles(h5["particles"], 0, 4)
+
+    assert len(particles) == 4
+    assert all(isinstance(particle, pylhe.LHEParticle) for particle in particles)
+
+    assert particles[0].id == 1
+    assert particles[0].status == -1
+    assert particles[0].pz == pytest.approx(12.38393852)
+
+    assert particles[2].id == 11
+    assert particles[2].e == pytest.approx(55.07043451)
+
+
+def test_iter_lheh5_reads_nominal_weight_and_particles():
+    with h5py.File(TEST_HDF5_J7, "r") as h5:
+        event_iter = iter_lheh5(h5)
+        first_event = next(event_iter)
+        second_event = next(event_iter)
+
+    assert first_event.eventinfo.weight == pytest.approx(0.0)
+    assert first_event.eventinfo.nparticles == 10
+
+    assert second_event.eventinfo.pid == 1
+    assert second_event.eventinfo.nparticles == 10
+    assert second_event.eventinfo.weight == pytest.approx(58474.2496)
+    assert len(second_event.particles) == 10
+    assert second_event.particles[0].id == 21
+    assert second_event.particles[2].id == 25
+    assert second_event.particles[2].m == pytest.approx(125.0)
+
+
+def test_read_init_matches_lheinit_specification():
+    with h5py.File(TEST_HDF5, "r") as h5:
+        init = read_init(h5)
+
+    assert isinstance(init, pylhe.LHEInit)
+    assert init.initInfo.beamA == 2212
+    assert init.initInfo.beamB == 2212
+    assert init.initInfo.energyA == pytest.approx(7000.0)
+    assert init.initInfo.energyB == pytest.approx(7000.0)
+    assert init.initInfo.PDFsetA == 13000
+    assert init.initInfo.PDFsetB == 13000
+    assert init.initInfo.weightingStrategy == 1
+    assert init.initInfo.numProcesses == 1
+
+    assert init.generators == []
+    assert len(init.procInfo) == 1
+    assert init.procInfo[0].procId == 1
+    assert init.procInfo[0].xSection == pytest.approx(1661.5257101139289)
+    assert init.procInfo[0].error == pytest.approx(6.367380198171124)
+    assert init.procInfo[0].unitWeight == pytest.approx(2.330218119536726e-05)

--- a/tests/test_lheh5_reader.py
+++ b/tests/test_lheh5_reader.py
@@ -7,12 +7,9 @@ import skhep_testdata
 import pylhe
 from pylhe.lheh5 import get_particles, iter_lheh5, read_init
 
-TEST_HDF5 = skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5")
-TEST_HDF5_J7 = skhep_testdata.data_path("pylhe-testfile-sherpa.hdf5")
-
 
 def test_get_particles_returns_lheparticles():
-    with h5py.File(TEST_HDF5, "r") as h5:
+    with h5py.File(skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5"), "r") as h5:
         particles = get_particles(h5["particles"], 0, 4)
 
     assert len(particles) == 4
@@ -27,7 +24,7 @@ def test_get_particles_returns_lheparticles():
 
 
 def test_iter_lheh5_reads_nominal_weight_and_particles():
-    with h5py.File(TEST_HDF5_J7, "r") as h5:
+    with h5py.File(skhep_testdata.data_path("pylhe-testfile-sherpa.hdf5"), "r") as h5:
         event_iter = iter_lheh5(h5)
         first_event = next(event_iter)
         second_event = next(event_iter)
@@ -45,7 +42,7 @@ def test_iter_lheh5_reads_nominal_weight_and_particles():
 
 
 def test_read_init_matches_lheinit_specification():
-    with h5py.File(TEST_HDF5, "r") as h5:
+    with h5py.File(skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5"), "r") as h5:
         init = read_init(h5)
 
     assert isinstance(init, pylhe.LHEInit)

--- a/tests/test_lheh5_reader.py
+++ b/tests/test_lheh5_reader.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import h5py
 import pytest
+import skhep_testdata
 
 import pylhe
 from pylhe.lheh5 import get_particles, iter_lheh5, read_init
 
-TEST_HDF5 = Path(__file__).with_name("test.hdf5")
-TEST_HDF5_J7 = Path(__file__).with_name("j7_1.hdf5")
+TEST_HDF5 = skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5")
+TEST_HDF5_J7 = skhep_testdata.data_path("pylhe-testfile-sherpa.hdf5")
 
 
 def test_get_particles_returns_lheparticles():

--- a/tests/test_lheh5_reader.py
+++ b/tests/test_lheh5_reader.py
@@ -41,6 +41,19 @@ def test_read_iter_events_reads_nominal_weight_and_particles():
     assert second_event.particles[2].m == pytest.approx(125.0)
 
 
+def test_count_events_matches_hdf5_events_dataset_length():
+    path = skhep_testdata.data_path("pylhe-testfile-sherpa.hdf5")
+
+    with h5py.File(path, "r") as h5:
+        expected = len(h5["events"])
+
+    assert pylhe.LesHouchesEvents.count_events(path) == expected
+    assert pylhe.LHEFile.count_events(path) == expected
+    assert pylhe.LHEFile.count_events(path) == sum(
+        1 for _ in pylhe.LHEFile.fromfile(path).events
+    )
+
+
 def test_read_init_matches_lheinit_specification():
     with h5py.File(skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5"), "r") as h5:
         init = read_init(h5)

--- a/tests/test_lheh5_reader.py
+++ b/tests/test_lheh5_reader.py
@@ -5,7 +5,7 @@ import pytest
 import skhep_testdata
 
 import pylhe
-from pylhe.lheh5 import get_particles, iter_lheh5, read_init
+from pylhe.lheh5 import get_particles, read_init, read_iter_events
 
 
 def test_get_particles_returns_lheparticles():
@@ -23,9 +23,9 @@ def test_get_particles_returns_lheparticles():
     assert particles[2].e == pytest.approx(55.07043451)
 
 
-def test_iter_lheh5_reads_nominal_weight_and_particles():
+def test_read_iter_events_reads_nominal_weight_and_particles():
     with h5py.File(skhep_testdata.data_path("pylhe-testfile-sherpa.hdf5"), "r") as h5:
-        event_iter = iter_lheh5(h5)
+        event_iter = read_iter_events(h5)
         first_event = next(event_iter)
         second_event = next(event_iter)
 

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import h5py
 import pytest
 import skhep_testdata
@@ -235,6 +237,49 @@ def test_lheh5_hpcgen_roundtrip(tmp_path):
 
     with h5py.File(roundtrip_path, "r") as h5:
         assert tuple(h5["version"][()]) == (2, 0, 0)
+
+
+def test_lheh5_write_streams_generator_across_multiple_flushes(tmp_path):
+    total_events = pylhe.lheh5._EVENT_CHUNK_ROWS + 5
+    template = _make_lhe()
+    template_events = list(template.events)
+    yielded = 0
+
+    def event_iter():
+        nonlocal yielded
+
+        for index in range(total_events):
+            event = deepcopy(template_events[index % len(template_events)])
+            event.eventinfo.pid = 1000 + index
+            event.attributes["trials"] = str(float(index))
+            yielded += 1
+            yield event
+
+    streamed = pylhe.LesHouchesEvents(init=template.init, events=event_iter())
+    path = tmp_path / "streamed.hdf5"
+
+    streamed.tofile(path, lheformat=pylhe.HDF5_GZ_FORMAT)
+
+    assert yielded == total_events
+
+    with h5py.File(path, "r") as h5:
+        assert h5["events"].shape == (total_events, len(pylhe.lheh5._EVENT_COLUMNS))
+        assert h5["particles"].shape == (
+            sum(event.eventinfo.nparticles for event in template_events)
+            * (total_events // len(template_events))
+            + sum(
+                template_events[index].eventinfo.nparticles
+                for index in range(total_events % len(template_events))
+            ),
+            len(pylhe.lheh5._PARTICLE_COLUMNS),
+        )
+
+    loaded = pylhe.LesHouchesEvents.fromfile(path, generator=False)
+    loaded_events = list(loaded.events)
+
+    assert len(loaded_events) == total_events
+    assert loaded_events[0].eventinfo.pid == 1000
+    assert loaded_events[-1].eventinfo.pid == 1000 + total_events - 1
 
 
 def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -23,7 +23,9 @@ def _column_names(dataset: h5py.Dataset) -> tuple[str, ...]:
     return ()
 
 
-def _assert_hdf5_core_equal(source_path, roundtrip_path) -> None:
+def _assert_hdf5_core_equal(
+    source_path, roundtrip_path, *, compare_version: bool = True
+) -> None:
     with (
         h5py.File(source_path, "r") as source,
         h5py.File(roundtrip_path, "r") as result,
@@ -35,10 +37,23 @@ def _assert_hdf5_core_equal(source_path, roundtrip_path) -> None:
             result_dataset = result[dataset_name]
 
             assert source_dataset.shape == result_dataset.shape
-            assert source_dataset[()].tolist() == result_dataset[()].tolist()
+            if dataset_name != "version" or compare_version:
+                assert source_dataset[()].tolist() == result_dataset[()].tolist()
 
             if isinstance(source_dataset, h5py.Dataset) and dataset_name != "version":
                 assert _column_names(source_dataset) == _column_names(result_dataset)
+
+
+def _copy_hdf5_with_version(source_path, target_path, version) -> None:
+    with (
+        h5py.File(source_path, "r") as source,
+        h5py.File(target_path, "w") as target,
+    ):
+        for dataset_name in source:
+            source.copy(dataset_name, target)
+
+        del target["version"]
+        target.create_dataset("version", data=version, dtype="i8")
 
 
 def _make_lhe() -> pylhe.LesHouchesEvents:
@@ -184,7 +199,7 @@ def test_lheh5_write_roundtrip(tmp_path):
 
     with h5py.File(path, "r") as h5:
         assert set(h5.keys()) == {"events", "init", "particles", "procInfo", "version"}
-        assert tuple(h5["version"][()]) == (1, 0, 0)
+        assert tuple(h5["version"][()]) == (2, 0, 0)
         assert tuple(h5["events"].attrs["properties"]) == (
             "pid",
             "nparticles",
@@ -207,13 +222,19 @@ def test_lheh5_write_roundtrip(tmp_path):
 
 
 def test_lheh5_hpcgen_roundtrip(tmp_path):
-    source_path = skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5")
+    fixture_path = skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5")
+    source_path = tmp_path / "hpcgen-v1.hdf5"
     roundtrip_path = tmp_path / "hpcgen-roundtrip.hdf5"
+
+    _copy_hdf5_with_version(fixture_path, source_path, version=(1, 0, 0))
 
     loaded = pylhe.LesHouchesEvents.fromfile(source_path, generator=False)
     loaded.tofile(roundtrip_path)
 
-    _assert_hdf5_core_equal(source_path, roundtrip_path)
+    _assert_hdf5_core_equal(source_path, roundtrip_path, compare_version=False)
+
+    with h5py.File(roundtrip_path, "r") as h5:
+        assert tuple(h5["version"][()]) == (2, 0, 0)
 
 
 def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -297,4 +297,4 @@ def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):
         h5py.File(path, "w") as h5,
         pytest.raises(ValueError, match=r"eventinfo.nparticles does not match"),
     ):
-        pylhe.lheh5.write(lhe, h5)
+        pylhe.lheh5.write(lhe, h5, lheformat=pylhe.HDF5_FORMAT)

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -364,3 +364,26 @@ def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):
         pytest.raises(ValueError, match=r"eventinfo.nparticles does not match"),
     ):
         pylhe.lheh5.write(lhe, h5, lheformat=pylhe.HDF5_FORMAT)
+
+
+def test_lheh5_write_rejects_inconsistent_num_processes(tmp_path):
+    path = tmp_path / "invalid-procinfo.hdf5"
+    lhe = pylhe.LesHouchesEvents(
+        init=pylhe.LHEInit(
+            initInfo=pylhe.LHEInitInfo(11, -11, 100.0, 100.0, 0, 0, 0, 0, 1, 2),
+            procInfo=[
+                pylhe.LHEProcInfo(xSection=1.0, error=0.1, unitWeight=1.0, procId=1)
+            ],
+            generators=[],
+        ),
+        events=[],
+    )
+
+    with (
+        h5py.File(path, "w") as h5,
+        pytest.raises(
+            ValueError,
+            match=r"initInfo.numProcesses does not match the number of procInfo rows",
+        ),
+    ):
+        pylhe.lheh5.write(lhe, h5, lheformat=pylhe.HDF5_FORMAT)

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -2,8 +2,43 @@ from __future__ import annotations
 
 import h5py
 import pytest
+import skhep_testdata
 
 import pylhe
+
+
+def _decode_attr_values(values: object) -> tuple[str, ...]:
+    return tuple(
+        value.decode() if isinstance(value, bytes) else str(value) for value in values
+    )
+
+
+def _column_names(dataset: h5py.Dataset) -> tuple[str, ...]:
+    dataset_name = dataset.name.rsplit("/", maxsplit=1)[-1]
+
+    for attr_name in ("properties", dataset_name):
+        if attr_name in dataset.attrs:
+            return _decode_attr_values(dataset.attrs[attr_name])
+
+    return ()
+
+
+def _assert_hdf5_core_equal(source_path, roundtrip_path) -> None:
+    with (
+        h5py.File(source_path, "r") as source,
+        h5py.File(roundtrip_path, "r") as result,
+    ):
+        assert set(source.keys()) == set(result.keys())
+
+        for dataset_name in source:
+            source_dataset = source[dataset_name]
+            result_dataset = result[dataset_name]
+
+            assert source_dataset.shape == result_dataset.shape
+            assert source_dataset[()].tolist() == result_dataset[()].tolist()
+
+            if isinstance(source_dataset, h5py.Dataset) and dataset_name != "version":
+                assert _column_names(source_dataset) == _column_names(result_dataset)
 
 
 def _make_lhe() -> pylhe.LesHouchesEvents:
@@ -27,6 +62,8 @@ def _make_lhe() -> pylhe.LesHouchesEvents:
                     error=0.1,
                     unitWeight=1.0,
                     procId=7,
+                    npLO=2,
+                    npNLO=1,
                 )
             ],
             generators=[],
@@ -73,6 +110,8 @@ def _make_lhe() -> pylhe.LesHouchesEvents:
                         9.0,
                     ),
                 ],
+                scales={"fscale": 88.0, "rscale": 94.0},
+                attributes={"trials": "12.0"},
             ),
             pylhe.LHEEvent(
                 eventinfo=pylhe.LHEEventInfo(
@@ -130,6 +169,8 @@ def _make_lhe() -> pylhe.LesHouchesEvents:
                         1.0,
                     ),
                 ],
+                scales={"fscale": 120.0, "rscale": 130.0},
+                attributes={"trials": "3.5"},
             ),
         ],
     )
@@ -163,6 +204,16 @@ def test_lheh5_write_roundtrip(tmp_path):
     assert loaded.init == lhe.init
     assert list(loaded.events) == list(lhe.events)
     assert list(loaded_lazy.events) == list(lhe.events)
+
+
+def test_lheh5_hpcgen_roundtrip(tmp_path):
+    source_path = skhep_testdata.data_path("pylhe-testfile-hpcgen.hdf5")
+    roundtrip_path = tmp_path / "hpcgen-roundtrip.hdf5"
+
+    loaded = pylhe.LesHouchesEvents.fromfile(source_path, generator=False)
+    loaded.tofile(roundtrip_path)
+
+    _assert_hdf5_core_equal(source_path, roundtrip_path)
 
 
 def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -202,6 +202,8 @@ def test_lheh5_write_roundtrip(tmp_path):
     with h5py.File(path, "r") as h5:
         assert set(h5.keys()) == {"events", "init", "particles", "procInfo", "version"}
         assert tuple(h5["version"][()]) == (2, 0, 0)
+        assert h5["events"].compression is None
+        assert h5["particles"].compression is None
         assert tuple(h5["events"].attrs["properties"]) == (
             "pid",
             "nparticles",
@@ -240,7 +242,14 @@ def test_lheh5_hpcgen_roundtrip(tmp_path):
 
 
 def test_lheh5_write_streams_generator_across_multiple_flushes(tmp_path):
-    total_events = pylhe.lheh5._EVENT_CHUNK_ROWS + 5
+    lheformat = pylhe.LHEHDF5Format(
+        compression="gzip",
+        compression_opts=4,
+        shuffle=True,
+        event_chunk_rows=3,
+        particle_chunk_rows=5,
+    )
+    total_events = lheformat.event_chunk_rows + 5
     template = _make_lhe()
     template_events = list(template.events)
     yielded = 0
@@ -258,11 +267,23 @@ def test_lheh5_write_streams_generator_across_multiple_flushes(tmp_path):
     streamed = pylhe.LesHouchesEvents(init=template.init, events=event_iter())
     path = tmp_path / "streamed.hdf5"
 
-    streamed.tofile(path, lheformat=pylhe.HDF5_GZ_FORMAT)
+    streamed.tofile(path, lheformat=lheformat)
 
     assert yielded == total_events
 
     with h5py.File(path, "r") as h5:
+        assert h5["events"].compression == "gzip"
+        assert h5["particles"].compression == "gzip"
+        assert h5["events"].shuffle
+        assert h5["particles"].shuffle
+        assert h5["events"].chunks == (
+            lheformat.event_chunk_rows,
+            len(pylhe.lheh5._EVENT_COLUMNS),
+        )
+        assert h5["particles"].chunks == (
+            lheformat.particle_chunk_rows,
+            len(pylhe.lheh5._PARTICLE_COLUMNS),
+        )
         assert h5["events"].shape == (total_events, len(pylhe.lheh5._EVENT_COLUMNS))
         assert h5["particles"].shape == (
             sum(event.eventinfo.nparticles for event in template_events)

--- a/tests/test_lheh5_writer.py
+++ b/tests/test_lheh5_writer.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import h5py
+import pytest
+
+import pylhe
+
+
+def _make_lhe() -> pylhe.LesHouchesEvents:
+    return pylhe.LesHouchesEvents(
+        init=pylhe.LHEInit(
+            initInfo=pylhe.LHEInitInfo(
+                beamA=11,
+                beamB=-11,
+                energyA=100.0,
+                energyB=100.0,
+                PDFgroupA=0,
+                PDFgroupB=0,
+                PDFsetA=0,
+                PDFsetB=0,
+                weightingStrategy=1,
+                numProcesses=1,
+            ),
+            procInfo=[
+                pylhe.LHEProcInfo(
+                    xSection=1.5,
+                    error=0.1,
+                    unitWeight=1.0,
+                    procId=7,
+                )
+            ],
+            generators=[],
+        ),
+        events=[
+            pylhe.LHEEvent(
+                eventinfo=pylhe.LHEEventInfo(
+                    nparticles=2,
+                    pid=7,
+                    weight=2.5,
+                    scale=91.2,
+                    aqed=0.01,
+                    aqcd=0.11,
+                ),
+                particles=[
+                    pylhe.LHEParticle(
+                        11,
+                        -1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        50.0,
+                        50.0,
+                        0.0,
+                        0.0,
+                        9.0,
+                    ),
+                    pylhe.LHEParticle(
+                        -11,
+                        -1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        -50.0,
+                        50.0,
+                        0.0,
+                        0.0,
+                        9.0,
+                    ),
+                ],
+            ),
+            pylhe.LHEEvent(
+                eventinfo=pylhe.LHEEventInfo(
+                    nparticles=3,
+                    pid=8,
+                    weight=3.5,
+                    scale=125.0,
+                    aqed=0.02,
+                    aqcd=0.12,
+                ),
+                particles=[
+                    pylhe.LHEParticle(
+                        22,
+                        2,
+                        1,
+                        2,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        125.0,
+                        125.0,
+                        0.0,
+                        0.0,
+                    ),
+                    pylhe.LHEParticle(
+                        13,
+                        1,
+                        3,
+                        3,
+                        0,
+                        0,
+                        10.0,
+                        0.0,
+                        40.0,
+                        41.231056,
+                        0.105,
+                        0.0,
+                        -1.0,
+                    ),
+                    pylhe.LHEParticle(
+                        -13,
+                        1,
+                        3,
+                        3,
+                        0,
+                        0,
+                        -10.0,
+                        0.0,
+                        -40.0,
+                        41.231056,
+                        0.105,
+                        0.0,
+                        1.0,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def test_lheh5_write_roundtrip(tmp_path):
+    lhe = _make_lhe()
+    path = tmp_path / "roundtrip.hdf5"
+
+    lhe.tofile(path)
+
+    with h5py.File(path, "r") as h5:
+        assert set(h5.keys()) == {"events", "init", "particles", "procInfo", "version"}
+        assert tuple(h5["version"][()]) == (1, 0, 0)
+        assert tuple(h5["events"].attrs["properties"]) == (
+            "pid",
+            "nparticles",
+            "start",
+            "trials",
+            "scale",
+            "fscale",
+            "rscale",
+            "aqed",
+            "aqcd",
+            "NOMINAL",
+        )
+
+    loaded = pylhe.LesHouchesEvents.fromfile(path, generator=False)
+    loaded_lazy = pylhe.LesHouchesEvents.fromfile(path)
+
+    assert loaded.init == lhe.init
+    assert list(loaded.events) == list(lhe.events)
+    assert list(loaded_lazy.events) == list(lhe.events)
+
+
+def test_lheh5_write_rejects_inconsistent_particle_count(tmp_path):
+    path = tmp_path / "invalid.hdf5"
+    lhe = pylhe.LesHouchesEvents(
+        init=pylhe.LHEInit(
+            initInfo=pylhe.LHEInitInfo(11, -11, 100.0, 100.0, 0, 0, 0, 0, 1, 1),
+            procInfo=[
+                pylhe.LHEProcInfo(xSection=1.0, error=0.1, unitWeight=1.0, procId=1)
+            ],
+            generators=[],
+        ),
+        events=[
+            pylhe.LHEEvent(
+                eventinfo=pylhe.LHEEventInfo(
+                    nparticles=1,
+                    pid=1,
+                    weight=1.0,
+                    scale=1.0,
+                    aqed=0.0,
+                    aqcd=0.0,
+                ),
+                particles=[
+                    pylhe.LHEParticle(
+                        11,
+                        -1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                    ),
+                    pylhe.LHEParticle(
+                        -11,
+                        -1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0.0,
+                        0.0,
+                        -1.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -1.0,
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with (
+        h5py.File(path, "w") as h5,
+        pytest.raises(ValueError, match=r"eventinfo.nparticles does not match"),
+    ):
+        pylhe.lheh5.write(lhe, h5)


### PR DESCRIPTION
- [x] read hdf5
- [x] write hdf5 
- [x] 100% coverage
- [x] polish code
- [x] polish docs
- [x] test it using `lheutils`
- [x] wait for https://github.com/scikit-hep/scikit-hep-testdata/pull/232 and increase version in pyproject.toml
- [x] when `tofile` gets `hdf5` or `lheh5` suffix switch to hdf5 output
- [x] removed python3.9 
- [x] ~pylhe lhe export and lheh5 export same result within pythia?~ Uses old 0.2.0 LHEHDF5

Close: #369 