### PR TITLE
feat: add to_numpy and from_numpy

### DIFF
--- a/src/pylhe/__init__.py
+++ b/src/pylhe/__init__.py
@@ -32,6 +32,7 @@ from pylhe import lheh5
 from pylhe._version import version as __version__
 
 from .awkward import to_awkward
+from .numpy import from_numpy, to_numpy
 
 __all__ = [
     "DEFAULT_FORMAT",
@@ -58,7 +59,9 @@ __all__ = [
     "LHEWeightFormat",
     "LHEXMLFormat",
     "__version__",
+    "from_numpy",
     "to_awkward",
+    "to_numpy",
 ]
 
 

--- a/src/pylhe/numpy.py
+++ b/src/pylhe/numpy.py
@@ -78,7 +78,7 @@ def to_numpy(
         event_iterable = event_iterable.events
 
     event_rows = []
-    particle_rows: list[tuple] = []
+    particle_rows: list[tuple[float, ...]] = []
     for event in event_iterable:
         ei = event.eventinfo
         event_rows.append(

--- a/src/pylhe/numpy.py
+++ b/src/pylhe/numpy.py
@@ -1,0 +1,162 @@
+"""
+`NumPy <https://numpy.org/>`_ interface for `pylhe`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+import numpy as np
+
+import pylhe
+
+__all__ = ["EVENT_DTYPE", "PARTICLE_DTYPE", "from_numpy", "to_numpy"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+EVENT_DTYPE = np.dtype(
+    [
+        ("start", np.int64),
+        ("nparticles", np.int32),
+        ("pid", np.int32),
+        ("weight", np.float64),
+        ("scale", np.float64),
+        ("aqed", np.float64),
+        ("aqcd", np.float64),
+    ]
+)
+"""Row layout of the ``"events"`` array: one row per event, where ``start`` and
+``nparticles`` point into the flat ``"particles"`` array (the same convention
+the LHEH5 format uses)."""
+
+PARTICLE_DTYPE = np.dtype(
+    [
+        ("id", np.int32),
+        ("status", np.int32),
+        ("mother1", np.int32),
+        ("mother2", np.int32),
+        ("color1", np.int32),
+        ("color2", np.int32),
+        ("px", np.float64),
+        ("py", np.float64),
+        ("pz", np.float64),
+        ("e", np.float64),
+        ("m", np.float64),
+        ("lifetime", np.float64),
+        ("spin", np.float64),
+    ]
+)
+"""Row layout of the ``"particles"`` array: one row per particle."""
+
+
+def to_numpy(
+    event_iterable: Iterable[pylhe.LHEEvent] | pylhe.LHEFile,
+) -> dict[str, np.ndarray]:
+    """Convert an iterable of LHEEvent instances to structured NumPy arrays.
+
+    Events with a variable number of particles are stored as two flat
+    rectilinear tables, following the same convention as the LHEH5 format: an
+    ``"events"`` array with one row per event, whose ``start`` and
+    ``nparticles`` columns index into a ``"particles"`` array with one row per
+    particle.
+
+    Note:
+        Named event weights, scales, attributes and optional comments have no
+        fixed-width columns and are therefore not stored; use
+        :func:`pylhe.to_awkward` if you need them.
+
+    Args:
+        event_iterable (iterable): An iterable of LHEEvent instances or LHEFile.
+
+    Returns:
+        dict: ``{"events": ..., "particles": ...}`` structured arrays.
+    """
+    if isinstance(event_iterable, pylhe.LHEFile):
+        event_iterable = event_iterable.events
+
+    event_rows = []
+    particle_rows: list[tuple] = []
+    for event in event_iterable:
+        ei = event.eventinfo
+        event_rows.append(
+            (
+                len(particle_rows),
+                len(event.particles),
+                ei.pid,
+                ei.weight,
+                ei.scale,
+                ei.aqed,
+                ei.aqcd,
+            )
+        )
+        particle_rows.extend(
+            (
+                p.id,
+                p.status,
+                p.mother1,
+                p.mother2,
+                p.color1,
+                p.color2,
+                p.px,
+                p.py,
+                p.pz,
+                p.e,
+                p.m,
+                p.lifetime,
+                p.spin,
+            )
+            for p in event.particles
+        )
+
+    return {
+        "events": np.array(event_rows, dtype=EVENT_DTYPE),
+        "particles": np.array(particle_rows, dtype=PARTICLE_DTYPE),
+    }
+
+
+def from_numpy(data: dict[str, np.ndarray]) -> Iterator[pylhe.LHEEvent]:
+    """Rebuild LHEEvent instances from arrays produced by :func:`to_numpy`.
+
+    Args:
+        data (dict): ``{"events": ..., "particles": ...}`` structured arrays,
+            as returned by :func:`to_numpy`.
+
+    Yields:
+        pylhe.LHEEvent: The reconstructed events.
+    """
+    events = data["events"]
+    particles = data["particles"]
+    for row in events:
+        start = int(row["start"])
+        nparticles = int(row["nparticles"])
+        yield pylhe.LHEEvent(
+            eventinfo=pylhe.LHEEventInfo(
+                nparticles=nparticles,
+                pid=int(row["pid"]),
+                weight=float(row["weight"]),
+                scale=float(row["scale"]),
+                aqed=float(row["aqed"]),
+                aqcd=float(row["aqcd"]),
+            ),
+            particles=[
+                pylhe.LHEParticle(
+                    id=int(p["id"]),
+                    status=int(p["status"]),
+                    mother1=int(p["mother1"]),
+                    mother2=int(p["mother2"]),
+                    color1=int(p["color1"]),
+                    color2=int(p["color2"]),
+                    px=float(p["px"]),
+                    py=float(p["py"]),
+                    pz=float(p["pz"]),
+                    e=float(p["e"]),
+                    m=float(p["m"]),
+                    lifetime=float(p["lifetime"]),
+                    spin=float(p["spin"]),
+                )
+                for p in particles[start : start + nparticles]
+            ],
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,12 +27,23 @@ def test_top_level_api():
         "WEIGHTS_FORMAT",
         "WEIGHTS_GZ_FORMAT",
         "__version__",
+        "from_numpy",
         "to_awkward",
+        "to_numpy",
     ]
 
 
 def test_awkward_api():
     assert dir(pylhe.awkward) == ["to_awkward"]
+
+
+def test_numpy_api():
+    assert dir(pylhe.numpy) == [
+        "EVENT_DTYPE",
+        "PARTICLE_DTYPE",
+        "from_numpy",
+        "to_numpy",
+    ]
 
 
 def test_load_version():

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+import skhep_testdata
+
+import pylhe
+from pylhe.numpy import EVENT_DTYPE, PARTICLE_DTYPE
+
+TEST_FILE_WITHOUT_WEIGHTS = skhep_testdata.data_path("pylhe-testfile-pr29.lhe")
+TEST_FILE_WITH_WEIGHTS = skhep_testdata.data_path("pylhe-testlhef3.lhe")
+
+
+def test_to_numpy():
+    data = pylhe.to_numpy(pylhe.LesHouchesEvents.fromfile(TEST_FILE_WITHOUT_WEIGHTS))
+    events, particles = data["events"], data["particles"]
+
+    assert events.dtype == EVENT_DTYPE
+    assert particles.dtype == PARTICLE_DTYPE
+    assert len(events) == 791
+    assert len(particles) == events["nparticles"].sum()
+
+    # start/nparticles must tile the particles array contiguously
+    assert events["start"][0] == 0
+    assert np.array_equal(
+        events["start"][1:], events["start"][:-1] + events["nparticles"][:-1]
+    )
+    assert events["start"][-1] + events["nparticles"][-1] == len(particles)
+
+    # same anchor values as the awkward interface tests
+    first = particles[events["start"][0]]
+    assert first["px"] == pytest.approx(-3.1463804033e-01)
+    assert first["py"] == pytest.approx(-6.3041724109e-01)
+    assert first["pz"] == pytest.approx(8.5343193374e00)
+    assert first["e"] == pytest.approx(8.5644657479e00)
+
+
+def test_to_numpy_weights_dropped():
+    # named weights have no fixed-width column; conversion works, weights are dropped
+    data = pylhe.to_numpy(pylhe.LesHouchesEvents.fromfile(TEST_FILE_WITH_WEIGHTS))
+    assert len(data["events"]) == 59
+    assert data["events"].dtype.names == EVENT_DTYPE.names
+
+
+def test_roundtrip():
+    original = list(pylhe.LesHouchesEvents.fromfile(TEST_FILE_WITHOUT_WEIGHTS).events)
+    back = list(pylhe.from_numpy(pylhe.to_numpy(original)))
+
+    assert len(back) == len(original)
+    for orig_event, new_event in zip(original, back):
+        assert new_event.eventinfo == orig_event.eventinfo
+        assert new_event.particles == orig_event.particles
+
+
+def test_empty():
+    data = pylhe.to_numpy([])
+    assert data["events"].shape == (0,)
+    assert data["particles"].shape == (0,)
+    assert data["events"].dtype == EVENT_DTYPE
+    assert data["particles"].dtype == PARTICLE_DTYPE
+    assert list(pylhe.from_numpy(data)) == []

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -45,7 +45,7 @@ def test_roundtrip():
     back = list(pylhe.from_numpy(pylhe.to_numpy(original)))
 
     assert len(back) == len(original)
-    for orig_event, new_event in zip(original, back):
+    for orig_event, new_event in zip(original, back, strict=True):
         assert new_event.eventinfo == orig_event.eventinfo
         assert new_event.particles == orig_event.particles
 


### PR DESCRIPTION
Closes #387.

Adds `pylhe.to_numpy` / `pylhe.from_numpy`.

Since events have a variable number of particles, `to_numpy` returns two flat structured arrays — `"events"` (one row per event, with `start` + `nparticles` columns) and `"particles"` (one row per particle) — i.e. the same convention the LHEH5 format already uses, so the NumPy and HDF5 views of an LHE file stay consistent with each other. `from_numpy` walks the offsets and rebuilds `LHEEvent` objects; the round trip is exact (there's a test comparing every event and particle against the parsed originals).

Named weights, scales, attributes and `#` comments don't fit fixed-width columns, so they're deliberately not stored — the docstring points people to `to_awkward` for the lossless path. Row layouts are exposed as `pylhe.numpy.EVENT_DTYPE` / `PARTICLE_DTYPE` (int32/float64; nuclear PDG codes still fit int32).

Happy to change the layout or dtypes if you had something else in mind for the hdf5 direction — the `start`/`nparticles` pairing seemed like the natural bridge given lheh5 is already in the tree.