### PR TITLE
fix: refactor empty/missing event_scale and event_trials to NaN in lheh5

### DIFF
--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -227,7 +227,7 @@ def _event_trials(event: pylhe.LHEEvent) -> float:
     try:
         return float(trials)
     except ValueError:
-        return 0.0
+        return float("nan")
 
 
 def get_particles(
@@ -443,8 +443,8 @@ def write(
                 start,
                 _event_trials(event),
                 event.eventinfo.scale,
-                _event_scale(event, "fscale", "muf", float("nan")),
-                _event_scale(event, "rscale", "mur", float("nan")),
+                _event_scale(event, "fscale", "muf", default=float("nan")),
+                _event_scale(event, "rscale", "mur", default=float("nan")),
                 event.eventinfo.aqed,
                 event.eventinfo.aqcd,
                 event.eventinfo.weight,

--- a/src/pylhe/lheh5.py
+++ b/src/pylhe/lheh5.py
@@ -210,7 +210,7 @@ def _append_rows(dataset: h5py.Dataset, rows: list[list[float]]) -> None:
     dataset[start:stop] = rows
 
 
-def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> float:
+def _event_scale(event: pylhe.LHEEvent, *names: str, default: float) -> float:
     for name in names:
         value = event.scales.get(name)
         if value is not None:
@@ -222,7 +222,7 @@ def _event_scale(event: pylhe.LHEEvent, *names: str, default: float = 0.0) -> fl
 def _event_trials(event: pylhe.LHEEvent) -> float:
     trials = event.attributes.get("trials")
     if trials is None:
-        return 0.0
+        return float("nan")
 
     try:
         return float(trials)
@@ -443,8 +443,8 @@ def write(
                 start,
                 _event_trials(event),
                 event.eventinfo.scale,
-                _event_scale(event, "fscale", "muf"),
-                _event_scale(event, "rscale", "mur"),
+                _event_scale(event, "fscale", "muf", float("nan")),
+                _event_scale(event, "rscale", "mur", float("nan")),
                 event.eventinfo.aqed,
                 event.eventinfo.aqcd,
                 event.eventinfo.weight,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -122,7 +122,7 @@ def test_lheh5_event_scale_returns_default_when_names_missing():
     assert pylhe.lheh5._event_scale(event, "fscale", "muf", default=9.5) == 9.5
 
 
-def test_lheh5_event_trials_returns_zero_for_missing_or_invalid_trials():
+def test_lheh5_event_trials_returns_nan_for_missing_or_invalid_trials():
     missing_trials_event = pylhe.LHEEvent(
         eventinfo=pylhe.LHEEventInfo(0, 0, 0.0, 0.0, 0.0, 0.0),
         particles=[],

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 import io
+import math
 import os
 import tempfile
 import xml.etree.ElementTree as ET
@@ -132,8 +133,8 @@ def test_lheh5_event_trials_returns_zero_for_missing_or_invalid_trials():
         attributes={"trials": "not-a-float"},
     )
 
-    assert pylhe.lheh5._event_trials(missing_trials_event) == 0.0
-    assert pylhe.lheh5._event_trials(invalid_trials_event) == 0.0
+    assert math.isnan(pylhe.lheh5._event_trials(missing_trials_event))
+    assert math.isnan(pylhe.lheh5._event_trials(invalid_trials_event))
 
 
 def test_lheh5_append_rows_returns_early_for_empty_rows(tmp_path):


### PR DESCRIPTION
Updated _event_scale to accept a float default value and modified _event_trials to return NaN instead of 0.0 when trials are None.

Part-of: https://github.com/scikit-hep/pylhe/issues/408