### PR TITLE
chore: Fix the all-contributors emoji key link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The preferred BibTeX entry for citation of `pylhe` is both the published paper a
 
 ## Contributors
 
-We hereby acknowledge the contributors that made this project possible ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+We hereby acknowledge the contributors that made this project possible ([emoji key](https://allcontributors.org/docs/emoji-key)):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
The emoji key link in the contributors section points at `https://allcontributors.org/docs/en/emoji-key`, which returns 404. The site dropped the `/en` locale segment from its docs paths.

Verified: `https://allcontributors.org/docs/en/emoji-key` returns 404, `https://allcontributors.org/docs/emoji-key` returns 200 and serves the contribution-type table.